### PR TITLE
Fix workout setup latency, weight suggestions, and session reliability

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,6 +26,7 @@ WebBrowser.maybeCompleteAuthSession();
 const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY as string | undefined;
 const convexUrl = process.env.EXPO_PUBLIC_CONVEX_URL as string | undefined;
 const convexClient = new ConvexReactClient(convexUrl ?? '', {
+  logger: false,
   unsavedChangesWarning: false,
 });
 
@@ -85,13 +86,16 @@ export default function RootLayout() {
         if (router.canGoBack()) router.back();
         else router.replace('/(tabs)');
       }}
-      style={{
-        width: 32,
+      android_ripple={{ color: 'transparent', borderless: false }}
+      style={({ pressed }) => ({
+        width: 40,
         height: 40,
         justifyContent: 'center',
-        alignItems: 'flex-start',
+        alignItems: 'center',
         padding: 0,
-      }}
+        backgroundColor: 'transparent',
+        opacity: pressed ? 0.65 : 1,
+      })}
       hitSlop={12}
     >
       <Ionicons

--- a/app/workout-setup/[templateId].tsx
+++ b/app/workout-setup/[templateId].tsx
@@ -13,20 +13,29 @@ import {
   roundGymDisplayWeight,
   type PlannedWeightValue,
 } from '@/utils/workoutPlanning';
-import { useUser } from '@clerk/clerk-expo';
+import { useAuth, useUser } from '@clerk/clerk-expo';
 import { Box, Button, HStack, Text, VStack } from '@gluestack-ui/themed';
 import { useFocusEffect } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useMutation, useQuery } from 'convex/react';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, ScrollView, StyleSheet, TextInput } from 'react-native';
 import { saveActiveSession } from '@/utils/activeWorkoutStorage';
+import {
+  fetchPublicWorkoutSetupBaseData,
+  startWorkoutFromTemplateOverHttp,
+} from '@/utils/publicWorkoutSummaryFetch';
+import {
+  loadCachedWorkoutSetupBaseData,
+  saveCachedWorkoutSetupBaseData,
+  type WorkoutSetupBaseData,
+} from '@/utils/workoutSetupCache';
 
 const keyExercisesByBodyPart: Record<string, { press?: string[], pull?: string[] }> = {
   legs: { 
     press: ['Back Squat', 'Front Squat', 'Leg Press'], 
-    pull: ['Romanian Deadlift', 'Stiff Leg Deadlift'] 
+    pull: ['Trap Bar Deadlift', 'Romanian Deadlift', 'Stiff Leg Deadlift'] 
   },
   chest: { 
     press: ['Bench Press', 'Incline Bench Press', 'Push-up'], 
@@ -48,9 +57,39 @@ const keyExercisesByBodyPart: Record<string, { press?: string[], pull?: string[]
 };
 
 const ACTIVE_SESSION_STORAGE_KEY = 'z-fit-active-session-id';
+const debugWorkoutLoading = process.env.EXPO_PUBLIC_WORKOUT_LOAD_DEBUG === 'true';
 
 const getParamValue = (value: string | string[] | undefined): string | undefined =>
   Array.isArray(value) ? value[0] : value;
+
+const withTimeout = async <T,>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+};
+
+const matchesExerciseKey = (exerciseName: string, key: string): boolean => {
+  const normalizedName = exerciseName.toLowerCase();
+  const normalizedKey = key.toLowerCase();
+  return normalizedName.includes(normalizedKey) || normalizedName.includes(normalizedKey.split(' ')[0]);
+};
+
+const getMovementTypeForBodyPart = (
+  bodyPart: string | undefined,
+  exercise: any,
+): 'press' | 'pull' | undefined => {
+  const bodyPartKeys = keyExercisesByBodyPart[bodyPart || ''] || { press: [], pull: [] };
+  const name = String(exercise?.name || '').toLowerCase();
+  if (bodyPartKeys.press?.some(key => matchesExerciseKey(name, key))) return 'press';
+  if (bodyPartKeys.pull?.some(key => matchesExerciseKey(name, key))) return 'pull';
+  return undefined;
+};
 
 export default function WorkoutSetupScreen() {
   const params = useLocalSearchParams();
@@ -60,12 +99,19 @@ export default function WorkoutSetupScreen() {
   const routeSetCount = getParamValue((params as any)?.setCount);
   const routeEstimatedMinutes = getParamValue((params as any)?.estimatedMinutes);
   const { user } = useUser();
+  const { getToken } = useAuth();
   const { anonKey: storedAnonKey, isLoaded: isAnonLoaded } = useAnonKey();
   const { weightUnit, convertWeight } = useWeightUnit();
   const { effectiveColorScheme } = useThemeMode();
   const isDark = effectiveColorScheme === 'dark';
+  const setupRequestedAtRef = useRef(Date.now());
+  const hasLoggedLiveBaseResultRef = useRef(false);
+  const hasLoggedHttpBaseResultRef = useRef(false);
+  const hadCachedBaseDataRef = useRef(false);
+  const [cachedSetupBaseData, setCachedSetupBaseData] = useState<WorkoutSetupBaseData | undefined>();
+  const [httpSetupBaseData, setHttpSetupBaseData] = useState<WorkoutSetupBaseData | undefined>();
 
-  const setupBaseData = useQuery(
+  const liveSetupBaseData = useQuery(
     api.sessions.getSetupBaseData,
     templateId
       ? {
@@ -73,9 +119,16 @@ export default function WorkoutSetupScreen() {
         }
       : 'skip'
   );
+  const setupBaseData =
+    liveSetupBaseData !== undefined
+      ? liveSetupBaseData
+      : httpSetupBaseData !== undefined
+        ? httpSetupBaseData
+        : cachedSetupBaseData;
+  const baseTemplate = setupBaseData?.template;
   const setupData = useQuery(
     api.sessions.getSetupData,
-    templateId && (user || isAnonLoaded)
+    templateId && baseTemplate && (user || isAnonLoaded)
       ? {
           templateId: templateId as Id<'templates'>,
           userId: undefined as any,
@@ -83,8 +136,8 @@ export default function WorkoutSetupScreen() {
         }
       : 'skip'
   );
-  const template = setupData?.template ?? setupBaseData?.template;
-  const exercises = (setupData?.exercises ?? setupBaseData?.exercises) as any[] | undefined;
+  const template = setupBaseData?.template;
+  const exercises = setupBaseData?.exercises as any[] | undefined;
   const progressions = setupData?.progressions;
   const latestCompleted = setupData?.latestCompleted;
   const latestAssessments = setupData?.latestAssessments;
@@ -94,7 +147,6 @@ export default function WorkoutSetupScreen() {
     routeSetCount ? `${routeSetCount} sets` : undefined,
     routeEstimatedMinutes ? `~${routeEstimatedMinutes} min` : undefined,
   ].filter(Boolean).join(' · ');
-  const startFromTemplate = useMutation(api.sessions.startFromTemplate);
   const recordAssessment = useMutation(api.sessions.recordAssessment);
   const [isStartingWorkout, setIsStartingWorkout] = useState(false);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
@@ -102,6 +154,63 @@ export default function WorkoutSetupScreen() {
   const [assessmentData, setAssessmentData] = useState<Record<string, { value: number; type: '1rm' | 'working' }>>({});
   const [step, setStep] = useState<'assessment' | 'weights'>('assessment');
   const [plannedWeights, setPlannedWeights] = useState<Record<string, PlannedWeightValue>>({});
+
+  useEffect(() => {
+    let isActive = true;
+    setCachedSetupBaseData(undefined);
+    setHttpSetupBaseData(undefined);
+    hadCachedBaseDataRef.current = false;
+    hasLoggedLiveBaseResultRef.current = false;
+    hasLoggedHttpBaseResultRef.current = false;
+    setupRequestedAtRef.current = Date.now();
+
+    if (!templateId) {
+      return () => {
+        isActive = false;
+      };
+    }
+
+    loadCachedWorkoutSetupBaseData(templateId)
+      .then((data) => {
+        if (!isActive) return;
+        hadCachedBaseDataRef.current = data !== undefined;
+        setCachedSetupBaseData(data);
+      })
+      .catch(() => {});
+
+    fetchPublicWorkoutSetupBaseData(templateId)
+      .then((data) => {
+        if (!isActive || data === undefined) return;
+        setHttpSetupBaseData(data);
+        saveCachedWorkoutSetupBaseData(templateId, data).catch(() => {});
+        if (debugWorkoutLoading && !hasLoggedHttpBaseResultRef.current) {
+          hasLoggedHttpBaseResultRef.current = true;
+          console.info('workout-setup-http-base-settled', {
+            templateId,
+            elapsedMs: Date.now() - setupRequestedAtRef.current,
+            hadCachedBaseData: hadCachedBaseDataRef.current,
+          });
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      isActive = false;
+    };
+  }, [templateId]);
+
+  useEffect(() => {
+    if (!templateId || liveSetupBaseData === undefined) return;
+    saveCachedWorkoutSetupBaseData(templateId, liveSetupBaseData).catch(() => {});
+    if (!debugWorkoutLoading || hasLoggedLiveBaseResultRef.current) return;
+    hasLoggedLiveBaseResultRef.current = true;
+    console.info('workout-setup-live-base-settled', {
+      templateId,
+      elapsedMs: Date.now() - setupRequestedAtRef.current,
+      hadCachedBaseData: cachedSetupBaseData !== undefined,
+      hadHttpBaseData: httpSetupBaseData !== undefined,
+    });
+  }, [cachedSetupBaseData, httpSetupBaseData, liveSetupBaseData, templateId]);
 
   const assessmentQuestions = useMemo<{ exercise: any; type: '1rm' | 'working'; question: string }[]>(() => {
     if (!template || !exercises) return [];
@@ -111,7 +220,7 @@ export default function WorkoutSetupScreen() {
       .filter((ex: any) => ex && ex.isWeighted);
     if (weightedByOrder.length === 0) return [];
     
-    const primary = weightedByOrder[0];
+    const primary = weightedByOrder.find((ex: any) => getMovementTypeForBodyPart(template.bodyPart, ex)) ?? weightedByOrder[0];
     return [{
       exercise: primary,
       type: '1rm' as const,
@@ -159,7 +268,6 @@ export default function WorkoutSetupScreen() {
       const weightedExercises = exercises.filter((ex: any) => ex.isWeighted);
       const effectiveAssessments = overrideAssessments ?? assessmentData;
       const itemsSorted = [...(template.items || [])].sort((a: any, b: any) => a.order - b.order);
-      const bodyPartKeys = keyExercisesByBodyPart[template.bodyPart] || { press: [], pull: [] };
       const weightedItems = itemsSorted
         .map((item: any) => ({
           item,
@@ -168,10 +276,7 @@ export default function WorkoutSetupScreen() {
         .filter(({ ex }: any) => !!ex);
 
       const movementTypeFor = (ex: any): 'press' | 'pull' | undefined => {
-        const name = String(ex?.name || '').toLowerCase();
-        if (bodyPartKeys.press?.some(key => name.includes(key.split(' ')[0].toLowerCase()))) return 'press';
-        if (bodyPartKeys.pull?.some(key => name.includes(key.split(' ')[0].toLowerCase()))) return 'pull';
-        return undefined;
+        return getMovementTypeForBodyPart(template.bodyPart, ex);
       };
 
       const directDataFor = (exerciseId: string): { value: number; type: '1rm' | 'working' } | undefined => {
@@ -207,7 +312,7 @@ export default function WorkoutSetupScreen() {
           return data ? { item, ex, data, movement: movementTypeFor(ex) } : null;
         })
         .filter(Boolean) as { item: any; ex: any; data: { value: number; type: '1rm' | 'working' }; movement?: 'press' | 'pull' }[];
-      const primaryReference = references[0];
+      const primaryReference = references.find(reference => reference.movement) ?? references[0];
 
       weightedItems.forEach(({ item, ex }: any) => {
         const exMeta = ex;
@@ -323,11 +428,19 @@ export default function WorkoutSetupScreen() {
         convertWeight
       );
       
-      const result = await startFromTemplate({ 
-        templateId: template._id,
-        anonKey: user ? undefined : (storedAnonKey || undefined),
-        plannedWeights: weightsInKg,
-      });
+      const authToken = user
+        ? await withTimeout(getToken({ template: 'convex' }), 3000, 'Unable to get auth token')
+        : undefined;
+      const result = await withTimeout(
+        startWorkoutFromTemplateOverHttp({
+          templateId: template._id,
+          anonKey: user ? undefined : (storedAnonKey || undefined),
+          plannedWeights: weightsInKg,
+          authToken,
+        }),
+        12000,
+        'Workout start timed out'
+      );
       const sessionId = typeof result === 'string' ? result : result.sessionId;
       const nextSessionId = String(sessionId);
       setActiveSessionId(nextSessionId);
@@ -340,9 +453,10 @@ export default function WorkoutSetupScreen() {
       } catch {}
       setIsStartingWorkout(false);
       router.push(`/workout/${sessionId}`);
-    } catch {
+    } catch (error) {
       setIsStartingWorkout(false);
-      Alert.alert('Failed to start workout', 'Something went wrong. Please try again.');
+      const message = error instanceof Error ? error.message : 'Something went wrong. Please try again.';
+      Alert.alert('Failed to start workout', message);
     }
   };
 

--- a/app/workout/[sessionId].tsx
+++ b/app/workout/[sessionId].tsx
@@ -4,6 +4,7 @@ import { useWorkoutLiveActivity } from "@/hooks/useLiveActivity";
 import { useWeightUnit } from "@/hooks/useWeightUnit";
 import { getDisplayIncrement } from "@/utils/workoutPlanning";
 import { Ionicons } from "@expo/vector-icons";
+import { useAuth, useUser } from "@clerk/clerk-expo";
 import { Box, Button, HStack, Text, VStack } from "@gluestack-ui/themed";
 import { usePreventRemove } from "@react-navigation/native";
 import { useMutation, useQuery } from "convex/react";
@@ -39,9 +40,26 @@ import {
   savePendingWorkoutOperations,
   type WorkoutOperation,
 } from "@/utils/activeWorkoutStorage";
+import { cancelWorkoutSessionOverHttp } from "@/utils/publicWorkoutSummaryFetch";
+import { useAnonKey } from "@/hooks/useAnonKey";
+
+const withTimeout = async <T,>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+};
 
 export default function WorkoutSessionScreen() {
   const { sessionId } = useLocalSearchParams<{ sessionId: Id<"sessions"> }>();
+  const { user } = useUser();
+  const { getToken } = useAuth();
+  const { anonKey: storedAnonKey } = useAnonKey();
   const { weightUnit, convertWeight, formatWeight } = useWeightUnit();
   const { effectiveColorScheme } = useThemeMode();
   const remoteSession = useQuery(
@@ -108,7 +126,6 @@ export default function WorkoutSessionScreen() {
       );
     }
   });
-  const cancelSession = useMutation(api.sessions.cancelSession);
   const updatePlannedWeight = useMutation(api.sessions.updatePlannedWeight).withOptimisticUpdate((localStore, args) => {
     const current = localStore.getQuery(api.sessions.getSession, { sessionId: args.sessionId });
     if (current !== undefined) {
@@ -434,7 +451,20 @@ export default function WorkoutSessionScreen() {
                 setLiveActivityId(null);
               }
               if (sessionId) {
-                await cancelSession({ sessionId: sessionId as Id<"sessions"> });
+                const cancelSessionId = String(sessionId);
+                const cancelAnonKey = user ? undefined : (storedAnonKey || undefined);
+                const authToken = user
+                  ? await withTimeout(getToken({ template: "convex" }), 3000, "Unable to get auth token")
+                  : undefined;
+                await withTimeout(
+                  cancelWorkoutSessionOverHttp({
+                    sessionId: cancelSessionId,
+                    anonKey: cancelAnonKey,
+                    authToken,
+                  }),
+                  12000,
+                  "Workout cancel timed out"
+                );
                 await removePendingWorkoutOperationsForSession(String(sessionId));
                 setPendingOperations((prev) =>
                   {
@@ -445,6 +475,7 @@ export default function WorkoutSessionScreen() {
                 );
               }
               await clearActiveSession();
+              cancelPromptOpenRef.current = false;
               navigateHomeAfterCleanup();
             } catch {
               isCancellingWorkoutRef.current = false;
@@ -463,13 +494,15 @@ export default function WorkoutSessionScreen() {
       },
     );
   }, [
-    cancelSession,
     endWorkoutActivity,
+    getToken,
     isAnyOverlayActive,
     isCancellingWorkout,
     liveActivityId,
     navigateHomeAfterCleanup,
     sessionId,
+    storedAnonKey,
+    user,
   ]);
 
   usePreventRemove(!canLeaveWorkout && Boolean(sessionId), () => {
@@ -965,13 +998,16 @@ export default function WorkoutSessionScreen() {
       headerLeft: () => (
         <Pressable
           onPress={handleCancelWorkout}
-          style={{
-            width: 32,
+          android_ripple={{ color: "transparent", borderless: false }}
+          style={({ pressed }) => ({
+            width: 40,
             height: 40,
             justifyContent: "center",
-            alignItems: "flex-start",
+            alignItems: "center",
             padding: 0,
-          }}
+            backgroundColor: "transparent",
+            opacity: pressed ? 0.65 : 1,
+          })}
           hitSlop={12}
         >
           <Ionicons

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -1,6 +1,9 @@
 import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import { computeNextPlannedWeight } from '../utils/workoutProgression';
+const RECENT_SESSION_LIMIT = 25;
+const SETUP_RECENT_SESSION_LIMIT = 8;
+
 async function resolveUserId(ctx: any, provided?: string) {
   if (provided) return provided;
   const identity = await ctx.auth.getUserIdentity?.();
@@ -48,14 +51,14 @@ async function getLatestAssessment(ctx: any, exerciseId: any, userId?: any, anon
   return null;
 }
 
-async function getRecentSessions(ctx: any, userId?: any, anonKey?: string) {
+async function getRecentSessions(ctx: any, userId?: any, anonKey?: string, limit = RECENT_SESSION_LIMIT) {
   const sessions: any[] = [];
   if (userId) {
     const userSessions = await ctx.db
       .query('sessions')
       .withIndex('by_user_started', (q: any) => q.eq('userId', userId))
       .order('desc')
-      .take(25);
+      .take(limit);
     sessions.push(...userSessions);
   }
   if (anonKey) {
@@ -63,7 +66,7 @@ async function getRecentSessions(ctx: any, userId?: any, anonKey?: string) {
       .query('sessions')
       .withIndex('by_anon_started', (q: any) => q.eq('anonKey', anonKey))
       .order('desc')
-      .take(25);
+      .take(limit);
     sessions.push(...anonSessions);
   }
   return sessions.sort((a, b) => (b.startedAt || 0) - (a.startedAt || 0));
@@ -326,11 +329,15 @@ export const completeSession = mutation({
 });
 
 export const cancelSession = mutation({
-  args: { sessionId: v.id('sessions') },
-  handler: async (ctx, { sessionId }) => {
+  args: { sessionId: v.id('sessions'), anonKey: v.optional(v.string()) },
+  handler: async (ctx, { sessionId, anonKey }) => {
     const s = await ctx.db.get(sessionId);
     if (!s) return true;
     if (s.status !== 'active') return true;
+    const identityUserId = await resolveExistingUserId(ctx as any);
+    const ownsUserSession = s.userId !== undefined && identityUserId !== undefined && String(s.userId) === String(identityUserId);
+    const ownsAnonSession = s.anonKey !== undefined && anonKey !== undefined && s.anonKey === anonKey;
+    if (!ownsUserSession && !ownsAnonSession) throw new Error('Unauthorized');
     await ctx.db.delete(sessionId);
     return true;
   },
@@ -390,10 +397,9 @@ export const getSetupData = query({
     anonKey: v.optional(v.string()),
   },
   handler: async (ctx, { templateId, userId, anonKey }) => {
-    const baseData = await getTemplateWithExercises(ctx as any, templateId);
-    if (!baseData) return null;
+    const template = await ctx.db.get(templateId);
+    if (!template) return null;
 
-    const { template, exercises } = baseData;
     const exerciseIds = Array.from(new Set<any>(template.items.map((item: any) => item.exerciseId)));
     const effectiveUserId = await resolveExistingUserId(ctx as any, userId as any);
     const progressions: Record<string, any> = {};
@@ -416,11 +422,24 @@ export const getSetupData = query({
       }
     }
 
-    const missingLatest = exerciseIds.some((exId: any) => latestCompleted[exId] === undefined);
-    const sessions = missingLatest ? await getRecentSessions(ctx as any, effectiveUserId, anonKey) : [];
+    const assessments = await Promise.all(exerciseIds.map(async (exId: any) => ({
+      exId,
+      latest: await getLatestAssessment(ctx as any, exId, effectiveUserId, anonKey),
+    })));
+    for (const { exId, latest } of assessments) {
+      if (latest) latestAssessments[exId] = latest;
+    }
+
+    const missingLatest = exerciseIds.some(
+      (exId: any) => latestCompleted[exId] === undefined && latestAssessments[exId] === undefined
+    );
+    const sessions = missingLatest
+      ? await getRecentSessions(ctx as any, effectiveUserId, anonKey, SETUP_RECENT_SESSION_LIMIT)
+      : [];
 
     for (const exId of exerciseIds) {
       if (latestCompleted[exId] !== undefined) continue;
+      if (latestAssessments[exId] !== undefined) continue;
       for (const session of sessions) {
         const exercise = session.exercises?.find((ex: any) => ex.exerciseId === exId);
         if (!exercise) continue;
@@ -435,17 +454,7 @@ export const getSetupData = query({
       }
     }
 
-    const assessments = await Promise.all(exerciseIds.map(async (exId: any) => ({
-      exId,
-      latest: await getLatestAssessment(ctx as any, exId, effectiveUserId, anonKey),
-    })));
-    for (const { exId, latest } of assessments) {
-      if (latest) latestAssessments[exId] = latest;
-    }
-
     return {
-      template,
-      exercises,
       progressions,
       latestCompleted,
       latestAssessments,

--- a/utils/publicWorkoutSummaryFetch.ts
+++ b/utils/publicWorkoutSummaryFetch.ts
@@ -1,16 +1,33 @@
 import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import type { WorkoutSetupBaseData } from '@/utils/workoutSetupCache';
 import { type WorkoutTemplateSummary } from '@/utils/workoutSummaryCache';
+import type { PlannedWeightValue } from '@/utils/workoutPlanning';
 import { ConvexHttpClient } from 'convex/browser';
 
 let publicConvexClient: ConvexHttpClient | null = null;
 
-function getPublicConvexClient() {
+function getConvexUrl() {
   const convexUrl = process.env.EXPO_PUBLIC_CONVEX_URL;
   if (!convexUrl) return null;
+  return convexUrl;
+}
+
+function getPublicConvexClient() {
+  const convexUrl = getConvexUrl();
+  if (!convexUrl) return null;
   if (!publicConvexClient) {
-    publicConvexClient = new ConvexHttpClient(convexUrl);
+    publicConvexClient = new ConvexHttpClient(convexUrl, { logger: false });
   }
   return publicConvexClient;
+}
+
+function createConvexHttpClient(authToken?: string | null) {
+  const convexUrl = getConvexUrl();
+  if (!convexUrl) return null;
+  const client = new ConvexHttpClient(convexUrl, { logger: false });
+  if (authToken) client.setAuth(authToken);
+  return client;
 }
 
 export async function fetchPublicWorkoutSummaries(
@@ -27,4 +44,51 @@ export async function fetchPublicWorkoutSummariesByCategory(): Promise<
   const client = getPublicConvexClient();
   if (!client) return undefined;
   return await client.query(api.templates.allCategorySummaries, {});
+}
+
+export async function fetchPublicWorkoutSetupBaseData(
+  templateId: string,
+): Promise<WorkoutSetupBaseData | undefined> {
+  const client = getPublicConvexClient();
+  if (!client) return undefined;
+  return await client.query(api.sessions.getSetupBaseData, {
+    templateId: templateId as Id<'templates'>,
+  });
+}
+
+export async function startWorkoutFromTemplateOverHttp({
+  templateId,
+  anonKey,
+  plannedWeights,
+  authToken,
+}: {
+  templateId: string;
+  anonKey?: string;
+  plannedWeights?: Record<string, PlannedWeightValue>;
+  authToken?: string | null;
+}) {
+  const client = createConvexHttpClient(authToken);
+  if (!client) throw new Error('Convex URL is not configured');
+  return await client.mutation(api.sessions.startFromTemplate, {
+    templateId: templateId as Id<'templates'>,
+    anonKey,
+    plannedWeights,
+  });
+}
+
+export async function cancelWorkoutSessionOverHttp({
+  sessionId,
+  anonKey,
+  authToken,
+}: {
+  sessionId: string;
+  anonKey?: string;
+  authToken?: string | null;
+}) {
+  const client = createConvexHttpClient(authToken);
+  if (!client) throw new Error('Convex URL is not configured');
+  return await client.mutation(api.sessions.cancelSession, {
+    sessionId: sessionId as Id<'sessions'>,
+    anonKey,
+  });
 }

--- a/utils/workoutPlanning.test.ts
+++ b/utils/workoutPlanning.test.ts
@@ -88,6 +88,47 @@ describe('getReferenceStrengthMultiplier', () => {
     expect(multiplier).toBe(0.25);
     expect(suggestedWeight).toBe(60);
   });
+
+  it('keeps side lateral raises below generic dumbbell scaling from bench', () => {
+    const benchPress = {
+      _id: 'bench-press',
+      name: 'Barbell Bench Press',
+      equipment: 'barbell' as const,
+      loadingMode: 'bar' as const,
+    };
+    const sideLateralRaise = {
+      _id: 'side-lateral-raise',
+      name: '1.5 Side Lateral Raise',
+      equipment: 'dumbbell' as const,
+      loadingMode: 'pair' as const,
+    };
+    const multiplier = getReferenceStrengthMultiplier(benchPress, sideLateralRaise);
+    const suggestedWeight = roundGymDisplayWeight(
+      estimateWeightForReps(300 * multiplier, 15),
+      'lbs',
+      sideLateralRaise,
+    );
+
+    expect(multiplier).toBe(0.3);
+    expect(suggestedWeight).toBe(60);
+  });
+
+  it('uses trap bar deadlift as a deadlift reference for dumbbell accessories', () => {
+    const trapBarDeadlift = {
+      _id: 'trap-bar-deadlift',
+      name: 'Trap Bar Deadlift',
+      equipment: 'barbell' as const,
+      loadingMode: 'bar' as const,
+    };
+    const reverseLunge = {
+      _id: 'reverse-lunge',
+      name: 'Dumbbell Reverse Lunge',
+      equipment: 'dumbbell' as const,
+      loadingMode: 'pair' as const,
+    };
+
+    expect(getReferenceStrengthMultiplier(trapBarDeadlift, reverseLunge)).toBe(0.3);
+  });
 });
 
 describe('buildPlannedWeightsInKg', () => {

--- a/utils/workoutPlanning.ts
+++ b/utils/workoutPlanning.ts
@@ -53,6 +53,7 @@ export function getReferenceStrengthMultiplier(
 
   if (referenceExercise?._id && referenceExercise._id === targetExercise?._id) return 1;
   if (targetName.includes('curl')) return isDeadliftReference ? 0.25 : 0.35;
+  if (targetName.includes('lateral raise') || targetName.includes('side lateral')) return isDeadliftReference ? 0.2 : 0.3;
   if (targetName.includes('face pull') || targetName.includes('rear delt') || targetName.includes('angels and devils')) return 0.18;
   if (targetName.includes('triceps') || targetName.includes('pushdown') || targetName.includes('extension')) return isDeadliftReference ? 0.22 : 0.35;
   if (targetName.includes('straight arm') || targetName.includes('pullover')) return isDeadliftReference ? 0.24 : 0.35;

--- a/utils/workoutSetupCache.ts
+++ b/utils/workoutSetupCache.ts
@@ -1,0 +1,65 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = 'z-fit-workout-setup-cache-v1';
+
+export type WorkoutSetupBaseData = {
+  template: any;
+  exercises: any[];
+} | null;
+
+type WorkoutSetupCache = {
+  updatedAt: number;
+  templates: Record<string, WorkoutSetupBaseData>;
+};
+
+const emptyCache = (): WorkoutSetupCache => ({
+  updatedAt: 0,
+  templates: {},
+});
+
+let cacheWriteQueue = Promise.resolve();
+
+function enqueueCacheWrite(operation: () => Promise<void>): Promise<void> {
+  const nextWrite = cacheWriteQueue.catch(() => {}).then(operation);
+  cacheWriteQueue = nextWrite.catch(() => {});
+  return nextWrite;
+}
+
+export async function loadWorkoutSetupCache(): Promise<WorkoutSetupCache> {
+  const raw = await AsyncStorage.getItem(STORAGE_KEY);
+  if (!raw) return emptyCache();
+  try {
+    const parsed = JSON.parse(raw) as Partial<WorkoutSetupCache>;
+    if (!parsed || typeof parsed !== 'object' || !parsed.templates) return emptyCache();
+    return {
+      updatedAt: typeof parsed.updatedAt === 'number' ? parsed.updatedAt : 0,
+      templates: parsed.templates,
+    };
+  } catch {
+    return emptyCache();
+  }
+}
+
+export async function loadCachedWorkoutSetupBaseData(templateId: string): Promise<WorkoutSetupBaseData | undefined> {
+  const cache = await loadWorkoutSetupCache();
+  return cache.templates[templateId];
+}
+
+export async function saveCachedWorkoutSetupBaseData(
+  templateId: string,
+  setupBaseData: WorkoutSetupBaseData,
+): Promise<void> {
+  await enqueueCacheWrite(async () => {
+    const cache = await loadWorkoutSetupCache();
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        updatedAt: Date.now(),
+        templates: {
+          ...cache.templates,
+          [templateId]: setupBaseData,
+        },
+      }),
+    );
+  });
+}


### PR DESCRIPTION
- Load workout setup from cache/HTTP so the screen appears instantly instead of waiting on the WebSocket
- Use Trap Bar Deadlift as the reference lift for Legs PPL 2 while keeping Reverse Hyper first in the workout order
- Lower lateral raise weight suggestions for chest day accessories
- Fix back button styling on active workout and setup screens
- Prevent "Starting..." and cancel hangs by using HTTP mutations with timeouts
- Secure session cancel with auth/ownership checks and avoid orphaned active sessions