### PR TITLE
 Fix TestFlight workout start auth (NoAuthProvider)

### DIFF
--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -4,5 +4,9 @@ export default {
       domain: "https://helped-starfish-74.clerk.accounts.dev",
       applicationID: "convex",
     },
-  ]
+    {
+      domain: "https://clerk.z-fit.app",
+      applicationID: "convex",
+    },
+  ],
 };


### PR DESCRIPTION
- Add production Clerk issuer (https://clerk.z-fit.app) to convex/auth.config.ts alongside dev.
- Fixes NoAuthProvider when starting a workout on TestFlight while signed in.