### PR TITLE
Fix reverse hyper weight prescription and simplify workout back button

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -87,21 +87,14 @@ export default function RootLayout() {
         else router.replace('/(tabs)');
       }}
       android_ripple={{ color: 'transparent', borderless: false }}
-      style={({ pressed }) => ({
-        width: 40,
-        height: 40,
-        justifyContent: 'center',
-        alignItems: 'center',
-        padding: 0,
-        backgroundColor: 'transparent',
-        opacity: pressed ? 0.65 : 1,
-      })}
+      style={({ pressed }) => ({ opacity: pressed ? 0.65 : 1 })}
       hitSlop={12}
     >
       <Ionicons
         name="chevron-back"
-        size={24}
+        size={28}
         color={effectiveColorScheme === 'dark' ? '#F8F9FA' : '#212529'}
+        style={{ marginLeft: -2 }}
       />
     </Pressable>
   );
@@ -153,6 +146,7 @@ export default function RootLayout() {
                   title: 'Setup',
                   headerBackVisible: false,
                   headerLeft: renderHeaderBackButton,
+                  headerLeftContainerStyle: { backgroundColor: 'transparent', paddingLeft: 4 },
                   headerBackButtonDisplayMode: 'minimal',
                   headerStyle: { backgroundColor: effectiveColorScheme === 'dark' ? '#343A40' : '#F8F9FA' },
                   headerTintColor: effectiveColorScheme === 'dark' ? '#F8F9FA' : '#212529',

--- a/app/workout/[sessionId].tsx
+++ b/app/workout/[sessionId].tsx
@@ -995,25 +995,20 @@ export default function WorkoutSessionScreen() {
   const workoutScreenOptions = useMemo(
     () => ({
       gestureEnabled: false,
+      headerBackVisible: false,
+      headerLeftContainerStyle: { backgroundColor: "transparent", paddingLeft: 4 },
       headerLeft: () => (
         <Pressable
           onPress={handleCancelWorkout}
           android_ripple={{ color: "transparent", borderless: false }}
-          style={({ pressed }) => ({
-            width: 40,
-            height: 40,
-            justifyContent: "center",
-            alignItems: "center",
-            padding: 0,
-            backgroundColor: "transparent",
-            opacity: pressed ? 0.65 : 1,
-          })}
+          style={({ pressed }) => ({ opacity: pressed ? 0.65 : 1 })}
           hitSlop={12}
         >
           <Ionicons
             name="chevron-back"
-            size={24}
+            size={28}
             color={effectiveColorScheme === "dark" ? "#F8F9FA" : "#212529"}
+            style={{ marginLeft: -2 }}
           />
         </Pressable>
       ),

--- a/utils/workoutPlanning.test.ts
+++ b/utils/workoutPlanning.test.ts
@@ -6,6 +6,7 @@ import {
   estimateWeightForReps,
   getDisplayIncrement,
   getReferenceStrengthMultiplier,
+  isMinimalLoadExercise,
   roundGymDisplayWeight,
 } from './workoutPlanning';
 import { convertWeight } from './weights';
@@ -128,6 +129,31 @@ describe('getReferenceStrengthMultiplier', () => {
     };
 
     expect(getReferenceStrengthMultiplier(trapBarDeadlift, reverseLunge)).toBe(0.3);
+  });
+
+  it('prescribes reverse hyper at bodyweight regardless of squat reference', () => {
+    const backSquat = {
+      _id: 'back-squat',
+      name: 'Back Squat',
+      equipment: 'barbell' as const,
+      loadingMode: 'bar' as const,
+    };
+    const reverseHyper = {
+      _id: 'reverse-hyper',
+      name: 'Reverse Hyper',
+      equipment: 'machine' as const,
+      loadingMode: 'bar' as const,
+    };
+
+    expect(isMinimalLoadExercise(reverseHyper)).toBe(true);
+    expect(getReferenceStrengthMultiplier(backSquat, reverseHyper)).toBe(0);
+    expect(
+      roundGymDisplayWeight(
+        estimateWeightForReps(300 * getReferenceStrengthMultiplier(backSquat, reverseHyper), 15),
+        'lbs',
+        reverseHyper,
+      ),
+    ).toBe(0);
   });
 });
 

--- a/utils/workoutPlanning.ts
+++ b/utils/workoutPlanning.ts
@@ -41,6 +41,10 @@ export function roundGymDisplayWeight(
   return Math.round(weight / increment) * increment;
 }
 
+export function isMinimalLoadExercise(exercise: ExerciseWeightMeta | undefined): boolean {
+  return String(exercise?.name ?? '').toLowerCase().includes('reverse hyper');
+}
+
 export function getReferenceStrengthMultiplier(
   referenceExercise: ExerciseWeightMeta | undefined,
   targetExercise: ExerciseWeightMeta | undefined,
@@ -52,6 +56,7 @@ export function getReferenceStrengthMultiplier(
   const isDeadliftReference = referenceName.includes('deadlift');
 
   if (referenceExercise?._id && referenceExercise._id === targetExercise?._id) return 1;
+  if (isMinimalLoadExercise(targetExercise)) return 0;
   if (targetName.includes('curl')) return isDeadliftReference ? 0.25 : 0.35;
   if (targetName.includes('lateral raise') || targetName.includes('side lateral')) return isDeadliftReference ? 0.2 : 0.3;
   if (targetName.includes('face pull') || targetName.includes('rear delt') || targetName.includes('angels and devils')) return 0.18;


### PR DESCRIPTION
- Default reverse hyper to bodyweight (0 lbs) instead of scaling from squat/deadlift reference lifts
- Preserve reverse hyper's own assessment, last completed, and progression data when available
- Simplify active workout and setup back buttons to a plain chevron with no background container