### PR TITLE
Add training groups with leaderboard, activity feed, and push notifications

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -47,6 +47,14 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="groups"
+        options={{
+          title: 'Groups',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="person.2.fill" color={color} />,
+          href: isSignedIn ? undefined : null,
+        }}
+      />
+      <Tabs.Screen
         name="profile"
         options={{
           title: 'Profile',

--- a/app/(tabs)/groups/[groupId].tsx
+++ b/app/(tabs)/groups/[groupId].tsx
@@ -1,0 +1,798 @@
+import { useAppToast } from '@/components/AppToast';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useThemeMode } from '@/hooks/useThemeMode';
+import { useUser } from '@clerk/clerk-expo';
+import { Ionicons } from '@expo/vector-icons';
+import { Box, HStack, Input, InputField, Pressable, Text, VStack } from '@gluestack-ui/themed';
+import { useMutation, useQuery } from 'convex/react';
+import { Image } from 'expo-image';
+import { Stack, router, useLocalSearchParams, type Href } from 'expo-router';
+import { useEffect, useMemo, useState } from 'react';
+import { Alert, ScrollView, StyleSheet } from 'react-native';
+
+type GroupView = 'leaderboard' | 'activity';
+type LeaderboardMetric = 'prsThisMonth' | 'workoutsThisWeek' | 'currentStreak';
+
+type PrDetail = { exerciseName: string; weight: number; completedAt: number; isPrimary: boolean };
+type WorkoutDetail = { completedAt: number; title: string };
+
+type ActivityExercise = { exerciseName: string; weight: number; reps: number; isPrimary: boolean; weighted: boolean };
+type ActivityItem = {
+  sessionId: Id<'sessions'>;
+  userId: Id<'users'>;
+  displayName: string;
+  imageUrl: string | null;
+  isCurrentUser: boolean;
+  completedAt: number;
+  title: string;
+  setCount: number;
+  exercises: ActivityExercise[];
+};
+
+type LeaderboardEntry = {
+  userId: Id<'users'>;
+  displayName: string;
+  imageUrl: string | null;
+  value: number;
+  rank: number;
+  isCurrentUser: boolean;
+  detail:
+    | { type: 'prsThisMonth'; prs: PrDetail[] }
+    | { type: 'workoutsThisWeek'; workouts: WorkoutDetail[] }
+    | { type: 'currentStreak'; lastWorkoutAt: number | null; workedToday: boolean };
+};
+
+const metricOptions: {
+  value: LeaderboardMetric;
+  label: string;
+  caption: string;
+  unit: string;
+  expandable: boolean;
+}[] = [
+  { value: 'prsThisMonth', label: 'PRs', caption: 'Personal records this month', unit: 'PRs', expandable: true },
+  { value: 'workoutsThisWeek', label: 'Workouts', caption: 'Sessions in the last 7 days', unit: 'sessions', expandable: true },
+  { value: 'currentStreak', label: 'Streak', caption: 'Consecutive training days', unit: 'days', expandable: false },
+];
+
+function formatRelativeDay(timestamp: number, now: number): string {
+  const day = new Date(timestamp);
+  day.setHours(0, 0, 0, 0);
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+  const diffDays = Math.round((today.getTime() - day.getTime()) / (24 * 60 * 60 * 1000));
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return day.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function formatActivityTime(timestamp: number, now: number): string {
+  const diffMs = now - timestamp;
+  const diffMinutes = Math.round(diffMs / (60 * 1000));
+  if (diffMinutes < 1) return 'Just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return formatRelativeDay(timestamp, now);
+}
+
+function getHighlight(entry: LeaderboardEntry, now: number): string {
+  if (entry.detail.type === 'prsThisMonth') {
+    if (entry.detail.prs.length === 0) return 'No new PRs';
+    const top = entry.detail.prs[0];
+    return `${top.exerciseName} · ${top.weight} lb`;
+  }
+  if (entry.detail.type === 'workoutsThisWeek') {
+    if (entry.detail.workouts.length === 0) return 'No workouts yet';
+    const latest = entry.detail.workouts[0];
+    return `${latest.title} · ${formatRelativeDay(latest.completedAt, now)}`;
+  }
+  if (entry.value === 0 || !entry.detail.lastWorkoutAt) return 'No active streak';
+  return entry.detail.workedToday ? 'Trained today' : `Last ${formatRelativeDay(entry.detail.lastWorkoutAt, now)}`;
+}
+
+function hasExpandableDetail(entry: LeaderboardEntry): boolean {
+  if (entry.detail.type === 'prsThisMonth') return entry.detail.prs.length > 0;
+  if (entry.detail.type === 'workoutsThisWeek') return entry.detail.workouts.length > 0;
+  return false;
+}
+
+function Avatar({
+  size,
+  imageUrl,
+  initial,
+  variant = 'default',
+}: {
+  size: number;
+  imageUrl: string | null;
+  initial: string;
+  variant?: 'default' | 'leader';
+}) {
+  if (imageUrl) {
+    return (
+      <Image
+        source={{ uri: imageUrl }}
+        style={{ width: size, height: size, borderRadius: size / 2 }}
+        contentFit="cover"
+        transition={150}
+      />
+    );
+  }
+
+  const isLeader = variant === 'leader';
+  return (
+    <Box
+      w={size}
+      h={size}
+      borderRadius={999}
+      justifyContent="center"
+      alignItems="center"
+      bg={isLeader ? '$primary0' : '$backgroundLight100'}
+      sx={{ _dark: { bg: isLeader ? '$textDark0' : '$backgroundDark100' } }}
+    >
+      <Text
+        size={size >= 44 ? 'lg' : 'md'}
+        fontWeight="$bold"
+        color={isLeader ? '$backgroundLight0' : '$textLight0'}
+        sx={{ _dark: { color: isLeader ? '$backgroundDark0' : '$textDark0' } }}
+      >
+        {initial}
+      </Text>
+    </Box>
+  );
+}
+
+function ExpandedDetail({ entry, now }: { entry: LeaderboardEntry; now: number }) {
+  if (entry.detail.type === 'prsThisMonth') {
+    return (
+      <VStack space="md">
+        {entry.detail.prs.map((pr, index) => (
+          <HStack key={`${pr.exerciseName}-${pr.completedAt}-${index}`} alignItems="center" justifyContent="space-between">
+            <HStack space="sm" alignItems="center" flex={1}>
+              <Box
+                w={6}
+                h={6}
+                borderRadius={999}
+                bg={pr.isPrimary ? '$primary0' : '$borderLight200'}
+                sx={{ _dark: { bg: pr.isPrimary ? '$textDark0' : '$borderDark0' } }}
+              />
+              <Text
+                size="sm"
+                fontWeight={pr.isPrimary ? '$semibold' : '$normal'}
+                color={pr.isPrimary ? '$textLight0' : '$textLight200'}
+                sx={{ _dark: { color: pr.isPrimary ? '$textDark0' : '$textDark200' } }}
+                numberOfLines={1}
+              >
+                {pr.exerciseName}
+              </Text>
+            </HStack>
+            <HStack space="md" alignItems="center">
+              <Text size="sm" fontWeight="$bold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                {pr.weight} lb
+              </Text>
+              <Text size="xs" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} w={60} textAlign="right">
+                {formatRelativeDay(pr.completedAt, now)}
+              </Text>
+            </HStack>
+          </HStack>
+        ))}
+      </VStack>
+    );
+  }
+
+  if (entry.detail.type === 'workoutsThisWeek') {
+    return (
+      <VStack space="md">
+        {entry.detail.workouts.map((workout) => (
+          <HStack key={workout.completedAt} alignItems="center" justifyContent="space-between" space="md">
+            <Text
+              size="sm"
+              fontWeight="$medium"
+              color="$textLight0"
+              sx={{ _dark: { color: '$textDark0' } }}
+              flex={1}
+              numberOfLines={1}
+            >
+              {workout.title}
+            </Text>
+            <Text size="xs" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }}>
+              {formatRelativeDay(workout.completedAt, now)}
+            </Text>
+          </HStack>
+        ))}
+      </VStack>
+    );
+  }
+
+  return null;
+}
+
+function ActivityCard({ item, now, mutedIcon }: { item: ActivityItem; now: number; mutedIcon: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const initial = (item.displayName.trim()[0] ?? 'A').toUpperCase();
+  const canExpand = item.exercises.length > 0;
+  const name = item.isCurrentUser ? 'You' : item.displayName;
+
+  return (
+    <Pressable onPress={() => canExpand && setExpanded((prev) => !prev)}>
+      {({ pressed }) => (
+        <Box
+          bg="$cardLight"
+          sx={{ _dark: { bg: '$cardDark', borderColor: '$borderDark0' } }}
+          borderColor="$borderLight0"
+          borderWidth={1}
+          borderRadius={18}
+          style={styles.card}
+          px={16}
+          py={14}
+          opacity={canExpand && pressed ? 0.92 : 1}
+        >
+          <HStack alignItems="center" space="md">
+            <Avatar size={42} imageUrl={item.imageUrl} initial={initial} />
+
+            <VStack flex={1} space="xs">
+              <Text size="md" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }} numberOfLines={1}>
+                <Text size="md" fontWeight="$bold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                  {name}
+                </Text>{' '}
+                did{' '}
+                <Text size="md" fontWeight="$bold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                  {item.title}
+                </Text>
+              </Text>
+              <Text size="xs" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} numberOfLines={1}>
+                {formatActivityTime(item.completedAt, now)} · {item.setCount} set{item.setCount === 1 ? '' : 's'}
+              </Text>
+            </VStack>
+
+            {canExpand && (
+              <Ionicons name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={mutedIcon} />
+            )}
+          </HStack>
+
+          {expanded && canExpand && (
+            <Box
+              mt={14}
+              pt={14}
+              borderTopWidth={1}
+              borderColor="$borderLight0"
+              sx={{ _dark: { borderColor: '$borderDark0' } }}
+            >
+              <VStack space="md">
+                {item.exercises.map((exercise, index) => (
+                  <HStack key={`${exercise.exerciseName}-${index}`} alignItems="center" justifyContent="space-between" space="md">
+                    <Text
+                      size="sm"
+                      fontWeight={exercise.isPrimary ? '$semibold' : '$normal'}
+                      color={exercise.isPrimary ? '$textLight0' : '$textLight200'}
+                      sx={{ _dark: { color: exercise.isPrimary ? '$textDark0' : '$textDark200' } }}
+                      flex={1}
+                      numberOfLines={1}
+                    >
+                      {exercise.exerciseName}
+                    </Text>
+                    <Text size="sm" fontWeight="$bold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                      {exercise.weighted ? `${exercise.weight} lb × ${exercise.reps}` : `${exercise.reps} reps`}
+                    </Text>
+                  </HStack>
+                ))}
+              </VStack>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Pressable>
+  );
+}
+
+export default function GroupLeaderboardScreen() {
+  const { effectiveColorScheme } = useThemeMode();
+  const isDark = effectiveColorScheme === 'dark';
+  const { showToast } = useAppToast();
+  const { isSignedIn, user } = useUser();
+  const convexUser = useQuery(api.users.me, isSignedIn && user ? { clerkUserId: user.id } : 'skip');
+
+  const { groupId } = useLocalSearchParams<{ groupId: string }>();
+  const isValidGroupId = Boolean(groupId && groupId !== 'index');
+  const parsedGroupId = isValidGroupId ? (groupId as Id<'groups'>) : undefined;
+
+  const [view, setView] = useState<GroupView>('leaderboard');
+  const [metric, setMetric] = useState<LeaderboardMetric>('prsThisMonth');
+  const [expandedUserId, setExpandedUserId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showInvite, setShowInvite] = useState(false);
+  const [invitingUserId, setInvitingUserId] = useState<Id<'users'> | null>(null);
+  const now = useMemo(() => Date.now(), []);
+  const timezoneOffsetMinutes = useMemo(() => new Date().getTimezoneOffset(), []);
+
+  const mutedIcon = isDark ? '#6C757D' : '#ADB5BD';
+  const headerIcon = isDark ? '#F8F9FA' : '#212529';
+
+  useEffect(() => {
+    if (groupId === 'index') {
+      router.replace('/groups' as Href);
+    }
+  }, [groupId]);
+
+  const group = useQuery(api.groups.getGroup, parsedGroupId ? { groupId: parsedGroupId } : 'skip');
+  const searchResults = useQuery(
+    api.groups.searchUsersForInvite,
+    parsedGroupId && searchQuery.trim().length >= 2 ? { groupId: parsedGroupId, query: searchQuery } : 'skip'
+  );
+  const pendingSentInvites = useQuery(
+    api.groups.listPendingInvitesForGroup,
+    parsedGroupId ? { groupId: parsedGroupId } : 'skip'
+  );
+  const leaderboard = useQuery(
+    api.leaderboard.forGroup,
+    parsedGroupId
+      ? { groupId: parsedGroupId, metric, periodStart: now, timezoneOffsetMinutes }
+      : 'skip'
+  ) as LeaderboardEntry[] | undefined;
+  const activity = useQuery(
+    api.leaderboard.recentActivity,
+    parsedGroupId && view === 'activity' ? { groupId: parsedGroupId } : 'skip'
+  ) as ActivityItem[] | undefined;
+  const leaveGroup = useMutation(api.groups.leave);
+  const sendInvite = useMutation(api.groups.sendInvite);
+
+  const selectedMetric = metricOptions.find((option) => option.value === metric) ?? metricOptions[0];
+  const filteredSearchResults = searchResults?.filter((result) => !convexUser || result.userId !== convexUser._id);
+  const memberCount = leaderboard?.length ?? 0;
+
+  const handleSelectView = (next: GroupView) => {
+    setView(next);
+    setExpandedUserId(null);
+  };
+
+  const handleSelectMetric = (next: LeaderboardMetric) => {
+    setMetric(next);
+    setExpandedUserId(null);
+  };
+
+  const handleToggleExpand = (entry: LeaderboardEntry) => {
+    if (!selectedMetric.expandable || !hasExpandableDetail(entry)) {
+      return;
+    }
+    setExpandedUserId((prev) => (prev === String(entry.userId) ? null : String(entry.userId)));
+  };
+
+  const handleInvite = async (userId: Id<'users'>, displayName: string) => {
+    if (!parsedGroupId || (convexUser && userId === convexUser._id)) {
+      return;
+    }
+    setInvitingUserId(userId);
+    try {
+      await sendInvite({ groupId: parsedGroupId, userId });
+      setSearchQuery('');
+      showToast(`Invite sent to ${displayName}`);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Failed to send invite');
+    } finally {
+      setInvitingUserId(null);
+    }
+  };
+
+  const handleLeave = () => {
+    Alert.alert('Leave group', `Are you sure you want to leave ${group?.name ?? 'this group'}?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Leave',
+        style: 'destructive',
+        onPress: async () => {
+          if (!parsedGroupId) {
+            return;
+          }
+          await leaveGroup({ groupId: parsedGroupId });
+          showToast('Left group');
+          router.replace('/groups' as Href);
+        },
+      },
+    ]);
+  };
+
+  const openMenu = () => {
+    Alert.alert(group?.name ?? 'Group', undefined, [
+      { text: 'Leave group', style: 'destructive', onPress: handleLeave },
+      { text: 'Cancel', style: 'cancel' },
+    ]);
+  };
+
+  if (group === null) {
+    return (
+      <Box flex={1} bg="$backgroundLight0" sx={{ _dark: { bg: '$backgroundDark0' } }} p={24} justifyContent="center">
+        <Stack.Screen options={{ title: 'Group' }} />
+        <Text textAlign="center" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+          Group not found
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box bg="$backgroundLight0" sx={{ _dark: { bg: '$backgroundDark0' } }} flex={1}>
+      <Stack.Screen
+        options={{
+          title: group?.name ?? 'Group',
+          headerRight: () => (
+            <HStack space="lg" alignItems="center" pr={4}>
+              <Pressable
+                hitSlop={8}
+                onPress={() => {
+                  setShowInvite((prev) => !prev);
+                  setSearchQuery('');
+                }}
+              >
+                <Ionicons name="person-add-outline" size={22} color={headerIcon} />
+              </Pressable>
+              <Pressable hitSlop={8} onPress={openMenu}>
+                <Ionicons name="ellipsis-horizontal" size={22} color={headerIcon} />
+              </Pressable>
+            </HStack>
+          ),
+        }}
+      />
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <VStack space="lg" p={20} pb={140}>
+          <HStack space="xl" px={4} borderBottomWidth={1} borderColor="$borderLight0" sx={{ _dark: { borderColor: '$borderDark0' } }}>
+            {(['leaderboard', 'activity'] as GroupView[]).map((tab) => {
+              const active = view === tab;
+              return (
+                <Pressable key={tab} onPress={() => handleSelectView(tab)}>
+                  <Box
+                    pt={2}
+                    pb={12}
+                    sx={{ _dark: { borderColor: active ? '$textDark0' : 'transparent' } }}
+                    borderBottomWidth={2}
+                    borderColor={active ? '$primary0' : 'transparent'}
+                  >
+                    <Text
+                      size="lg"
+                      fontWeight={active ? '$bold' : '$medium'}
+                      color={active ? '$textLight0' : '$textLight300'}
+                      sx={{ _dark: { color: active ? '$textDark0' : '$textDark300' } }}
+                    >
+                      {tab === 'leaderboard' ? 'Leaderboard' : 'Activity'}
+                    </Text>
+                  </Box>
+                </Pressable>
+              );
+            })}
+          </HStack>
+
+          {view === 'leaderboard' && (
+            <>
+            <Box
+              bg="$backgroundLight100"
+              sx={{ _dark: { bg: '$backgroundDark100' } }}
+              borderRadius={14}
+              p={4}
+            >
+              <HStack space="xs">
+                {metricOptions.map((option) => {
+                const active = metric === option.value;
+                return (
+                  <Pressable key={option.value} flex={1} onPress={() => handleSelectMetric(option.value)}>
+                    <Box
+                      bg={active ? '$cardLight' : 'transparent'}
+                      sx={{ _dark: { bg: active ? '$cardDark' : 'transparent' } }}
+                      style={active ? styles.segmentShadow : undefined}
+                      borderRadius={10}
+                      h={38}
+                      justifyContent="center"
+                      alignItems="center"
+                    >
+                      <Text
+                        size="sm"
+                        fontWeight={active ? '$bold' : '$medium'}
+                        color={active ? '$textLight0' : '$textLight300'}
+                        sx={{ _dark: { color: active ? '$textDark0' : '$textDark300' } }}
+                      >
+                        {option.label}
+                      </Text>
+                    </Box>
+                  </Pressable>
+                );
+              })}
+            </HStack>
+          </Box>
+
+              <HStack alignItems="center" justifyContent="space-between" px={4}>
+                <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }}>
+                  {selectedMetric.caption}
+                </Text>
+                {memberCount > 0 && (
+                  <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }}>
+                    {memberCount} member{memberCount === 1 ? '' : 's'}
+                  </Text>
+                )}
+              </HStack>
+            </>
+          )}
+
+          {view === 'activity' && (
+            <HStack alignItems="center" justifyContent="space-between" px={4}>
+              <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }}>
+                Latest workouts from your group
+              </Text>
+            </HStack>
+          )}
+
+          {showInvite && (
+            <Box
+              bg="$cardLight"
+              sx={{ _dark: { bg: '$cardDark', borderColor: '$borderDark0' } }}
+              borderColor="$borderLight0"
+              borderWidth={1}
+              borderRadius={18}
+              style={styles.card}
+              p={18}
+            >
+              <VStack space="md">
+                <HStack alignItems="center" justifyContent="space-between">
+                  <Text size="md" fontWeight="$semibold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                    Invite friends
+                  </Text>
+                  <Pressable hitSlop={8} onPress={() => { setShowInvite(false); setSearchQuery(''); }}>
+                    <Ionicons name="close" size={20} color={mutedIcon} />
+                  </Pressable>
+                </HStack>
+                <Box
+                  bg="$backgroundLight0"
+                  sx={{ _dark: { bg: '$backgroundDark0', borderColor: '$borderDark0' } }}
+                  borderColor="$borderLight0"
+                  borderWidth={1}
+                  borderRadius={12}
+                  px={14}
+                  flexDirection="row"
+                  alignItems="center"
+                >
+                  <Ionicons name="search" size={18} color={mutedIcon} />
+                  <Input flex={1} borderWidth={0} h={46}>
+                    <InputField
+                      placeholder="Search by name"
+                      placeholderTextColor={mutedIcon}
+                      value={searchQuery}
+                      onChangeText={setSearchQuery}
+                      autoFocus
+                      color="$textLight0"
+                      sx={{ _dark: { color: '$textDark0' } }}
+                    />
+                  </Input>
+                </Box>
+                {searchQuery.trim().length >= 2 && filteredSearchResults && filteredSearchResults.length === 0 && (
+                  <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }}>
+                    No users found
+                  </Text>
+                )}
+                {filteredSearchResults?.map((result) => (
+                  <HStack key={result.userId} justifyContent="space-between" alignItems="center" py={2}>
+                    <Text size="md" fontWeight="$medium" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }} flex={1} numberOfLines={1}>
+                      {result.displayName}
+                    </Text>
+                    <Pressable disabled={invitingUserId === result.userId} onPress={() => handleInvite(result.userId, result.displayName)}>
+                      {({ pressed }) => (
+                        <Box
+                          bg="$primary0"
+                          sx={{ _dark: { bg: '$textDark0' } }}
+                          borderRadius={10}
+                          h={34}
+                          px={16}
+                          justifyContent="center"
+                          alignItems="center"
+                          opacity={invitingUserId === result.userId ? 0.5 : pressed ? 0.85 : 1}
+                        >
+                          <Text color="$backgroundLight0" sx={{ _dark: { color: '$backgroundDark0' } }} fontWeight="$semibold" size="sm">
+                            Invite
+                          </Text>
+                        </Box>
+                      )}
+                    </Pressable>
+                  </HStack>
+                ))}
+                {pendingSentInvites && pendingSentInvites.length > 0 && (
+                  <VStack space="sm" pt={4}>
+                    <Text size="2xs" fontWeight="$bold" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} letterSpacing={1}>
+                      PENDING
+                    </Text>
+                    {pendingSentInvites.map((invite) => (
+                      <HStack key={invite._id} space="sm" alignItems="center">
+                        <Ionicons name="time-outline" size={14} color={mutedIcon} />
+                        <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }}>
+                          {invite.displayName}
+                        </Text>
+                      </HStack>
+                    ))}
+                  </VStack>
+                )}
+              </VStack>
+            </Box>
+          )}
+
+          {view === 'leaderboard' ? (
+            leaderboard === undefined ? (
+            <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} px={4}>
+              Loading…
+            </Text>
+          ) : leaderboard.length === 0 ? (
+            <Box
+              bg="$cardLight"
+              sx={{ _dark: { bg: '$cardDark', borderColor: '$borderDark0' } }}
+              borderColor="$borderLight0"
+              borderWidth={1}
+              borderRadius={20}
+              style={styles.card}
+              p={32}
+            >
+              <VStack space="md" alignItems="center">
+                <Ionicons name="trophy-outline" size={30} color={mutedIcon} />
+                <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} textAlign="center">
+                  Invite friends to start competing
+                </Text>
+                <Pressable onPress={() => setShowInvite(true)}>
+                  {({ pressed }) => (
+                    <Box
+                      bg="$primary0"
+                      sx={{ _dark: { bg: '$textDark0' } }}
+                      borderRadius={12}
+                      h={44}
+                      px={24}
+                      justifyContent="center"
+                      alignItems="center"
+                      opacity={pressed ? 0.85 : 1}
+                    >
+                      <Text color="$backgroundLight0" sx={{ _dark: { color: '$backgroundDark0' } }} fontWeight="$semibold" size="sm">
+                        Invite friends
+                      </Text>
+                    </Box>
+                  )}
+                </Pressable>
+              </VStack>
+            </Box>
+          ) : (
+            <VStack space="sm">
+              {leaderboard.map((entry) => {
+                const isLeader = entry.rank === 1 && entry.value > 0;
+                const expanded = expandedUserId === String(entry.userId);
+                const canExpand = selectedMetric.expandable && hasExpandableDetail(entry);
+                const initial = (entry.displayName.trim()[0] ?? 'A').toUpperCase();
+
+                return (
+                  <Pressable key={entry.userId} onPress={() => handleToggleExpand(entry)}>
+                    {({ pressed }) => (
+                      <Box
+                        bg="$cardLight"
+                        sx={{ _dark: { bg: '$cardDark', borderColor: '$borderDark0' } }}
+                        borderColor="$borderLight0"
+                        borderWidth={1}
+                        borderRadius={18}
+                        style={styles.card}
+                        px={16}
+                        py={14}
+                        opacity={canExpand && pressed ? 0.92 : 1}
+                      >
+                        <HStack alignItems="center" space="md">
+                          <Box w={20} alignItems="center">
+                            <Text
+                              size="md"
+                              fontWeight="$bold"
+                              color={isLeader ? '$textLight0' : '$textLight300'}
+                              sx={{ _dark: { color: isLeader ? '$textDark0' : '$textDark300' } }}
+                            >
+                              {entry.rank}
+                            </Text>
+                          </Box>
+
+                          <Avatar
+                            size={46}
+                            imageUrl={entry.imageUrl}
+                            initial={initial}
+                            variant={isLeader ? 'leader' : 'default'}
+                          />
+
+                          <VStack flex={1} space="xs">
+                            <Text
+                              size="md"
+                              fontWeight="$semibold"
+                              color="$textLight0"
+                              sx={{ _dark: { color: '$textDark0' } }}
+                              numberOfLines={1}
+                            >
+                              {entry.displayName}
+                              {entry.isCurrentUser ? ' (You)' : ''}
+                            </Text>
+                            <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} numberOfLines={1}>
+                              {getHighlight(entry, now)}
+                            </Text>
+                          </VStack>
+
+                          <VStack alignItems="flex-end" space="xs" minWidth={48}>
+                            <Text size="2xl" fontWeight="$bold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }} lineHeight={26}>
+                              {entry.value}
+                            </Text>
+                            <Text size="2xs" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} textTransform="uppercase" letterSpacing={0.5}>
+                              {selectedMetric.unit}
+                            </Text>
+                          </VStack>
+
+                          {canExpand && (
+                            <Ionicons name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={mutedIcon} />
+                          )}
+                        </HStack>
+
+                        {expanded && canExpand && (
+                          <Box
+                            mt={14}
+                            pt={14}
+                            borderTopWidth={1}
+                            borderColor="$borderLight0"
+                            sx={{ _dark: { borderColor: '$borderDark0' } }}
+                          >
+                            <ExpandedDetail entry={entry} now={now} />
+                          </Box>
+                        )}
+                      </Box>
+                    )}
+                  </Pressable>
+                );
+              })}
+            </VStack>
+            )
+          ) : activity === undefined ? (
+            <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} px={4}>
+              Loading…
+            </Text>
+          ) : activity.length === 0 ? (
+            <Box
+              bg="$cardLight"
+              sx={{ _dark: { bg: '$cardDark', borderColor: '$borderDark0' } }}
+              borderColor="$borderLight0"
+              borderWidth={1}
+              borderRadius={20}
+              style={styles.card}
+              p={32}
+            >
+              <VStack space="md" alignItems="center">
+                <Ionicons name="pulse-outline" size={30} color={mutedIcon} />
+                <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} textAlign="center">
+                  No recent activity yet
+                </Text>
+                <Text size="xs" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} textAlign="center">
+                  Completed workouts from the group will show up here
+                </Text>
+              </VStack>
+            </Box>
+          ) : (
+            <VStack space="sm">
+              {activity.map((item) => (
+                <ActivityCard key={item.sessionId} item={item} now={now} mutedIcon={mutedIcon} />
+              ))}
+            </VStack>
+          )}
+        </VStack>
+      </ScrollView>
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    flexGrow: 1,
+  },
+  card: {
+    shadowColor: '#000',
+    shadowOpacity: 0.04,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 1,
+  },
+  segmentShadow: {
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 1 },
+    elevation: 1,
+  },
+});

--- a/app/(tabs)/groups/_layout.tsx
+++ b/app/(tabs)/groups/_layout.tsx
@@ -1,0 +1,21 @@
+import { useThemeMode } from '@/hooks/useThemeMode';
+import { Stack } from 'expo-router';
+
+export default function GroupsLayout() {
+  const { effectiveColorScheme } = useThemeMode();
+  const isDark = effectiveColorScheme === 'dark';
+
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: isDark ? '#212529' : '#F8F9FA' },
+        headerTintColor: isDark ? '#F8F9FA' : '#212529',
+        headerShadowVisible: false,
+        headerBackButtonDisplayMode: 'minimal',
+      }}
+    >
+      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen name="[groupId]" options={{ title: '', headerTransparent: false }} />
+    </Stack>
+  );
+}

--- a/app/(tabs)/groups/index.tsx
+++ b/app/(tabs)/groups/index.tsx
@@ -1,0 +1,389 @@
+import { useAppToast } from '@/components/AppToast';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { Ionicons } from '@expo/vector-icons';
+import { Box, HStack, Input, InputField, Pressable, Text, VStack } from '@gluestack-ui/themed';
+import { useMutation, useQuery } from 'convex/react';
+import { router, type Href } from 'expo-router';
+import { useState } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet } from 'react-native';
+import { useThemeMode } from '@/hooks/useThemeMode';
+
+export default function GroupsScreen() {
+  const { effectiveColorScheme } = useThemeMode();
+  const isDark = effectiveColorScheme === 'dark';
+  const { showToast } = useAppToast();
+
+  const groups = useQuery(api.groups.listMine);
+  const pendingInvites = useQuery(api.groups.listMyPendingInvites);
+  const createGroup = useMutation(api.groups.create);
+  const acceptInvite = useMutation(api.groups.acceptInvite);
+  const declineInvite = useMutation(api.groups.declineInvite);
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [groupName, setGroupName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [respondingInviteId, setRespondingInviteId] = useState<Id<'groupInvitations'> | null>(null);
+
+  const mutedIcon = isDark ? '#6C757D' : '#ADB5BD';
+
+  const openCreate = () => {
+    setError(null);
+    setGroupName('');
+    setShowCreate(true);
+  };
+
+  const handleCreate = async () => {
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      const result = await createGroup({ name: groupName.trim() });
+      setGroupName('');
+      setShowCreate(false);
+      showToast('Group created');
+      router.push(`/groups/${result.groupId}` as Href);
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : 'Failed to create group');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleAccept = async (invitationId: Id<'groupInvitations'>) => {
+    setRespondingInviteId(invitationId);
+    try {
+      const groupId = await acceptInvite({ invitationId });
+      showToast('Joined group');
+      router.push(`/groups/${groupId}` as Href);
+    } catch (acceptError) {
+      showToast(acceptError instanceof Error ? acceptError.message : 'Failed to accept invite');
+    } finally {
+      setRespondingInviteId(null);
+    }
+  };
+
+  const handleDecline = async (invitationId: Id<'groupInvitations'>) => {
+    setRespondingInviteId(invitationId);
+    try {
+      await declineInvite({ invitationId });
+      showToast('Invitation declined');
+    } catch (declineError) {
+      showToast(declineError instanceof Error ? declineError.message : 'Failed to decline invite');
+    } finally {
+      setRespondingInviteId(null);
+    }
+  };
+
+  const hasInvites = pendingInvites && pendingInvites.length > 0;
+  const isLoading = groups === undefined;
+  const isEmpty = !isLoading && groups.length === 0 && !hasInvites;
+
+  return (
+    <Box bg="$backgroundLight0" sx={{ _dark: { bg: '$backgroundDark0' } }} flex={1}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <VStack space="2xl" p={24} pb={140}>
+          <HStack alignItems="flex-start" justifyContent="space-between" pt={32}>
+            <VStack space="sm" flex={1}>
+              <Text size="3xl" fontWeight="$bold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                Groups
+              </Text>
+              <Text size="md" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }}>
+                Compete and compare stats with friends
+              </Text>
+            </VStack>
+            <Pressable onPress={openCreate} hitSlop={8}>
+              {({ pressed }) => (
+                <Box
+                  bg="$primary0"
+                  sx={{ _dark: { bg: '$textDark0' } }}
+                  borderRadius={999}
+                  w={44}
+                  h={44}
+                  justifyContent="center"
+                  alignItems="center"
+                  opacity={pressed ? 0.85 : 1}
+                >
+                  <Ionicons name="add" size={26} color={isDark ? '#212529' : '#F8F9FA'} />
+                </Box>
+              )}
+            </Pressable>
+          </HStack>
+
+          {showCreate && (
+            <Box
+              bg="$cardLight"
+              sx={{ _dark: { bg: '$cardDark', borderColor: '$borderDark0' } }}
+              borderColor="$borderLight0"
+              borderWidth={1}
+              borderRadius={18}
+              style={styles.card}
+              p={20}
+            >
+              <VStack space="md">
+                <Text size="lg" fontWeight="$semibold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                  New group
+                </Text>
+                <Input borderRadius={12} borderColor="$borderLight0" sx={{ _dark: { borderColor: '$borderDark0' } }} h={48}>
+                  <InputField
+                    placeholder="e.g. Gym Crew"
+                    placeholderTextColor={mutedIcon}
+                    value={groupName}
+                    onChangeText={setGroupName}
+                    autoFocus
+                    color="$textLight0"
+                    sx={{ _dark: { color: '$textDark0' } }}
+                  />
+                </Input>
+                {error && (
+                  <Text size="sm" color="$error500">
+                    {error}
+                  </Text>
+                )}
+                <HStack space="md">
+                  <Pressable
+                    flex={1}
+                    onPress={() => {
+                      setShowCreate(false);
+                      setGroupName('');
+                      setError(null);
+                    }}
+                  >
+                    {({ pressed }) => (
+                      <Box
+                        borderColor="$borderLight0"
+                        sx={{ _dark: { borderColor: '$borderDark0' } }}
+                        borderWidth={1}
+                        borderRadius={12}
+                        h={48}
+                        justifyContent="center"
+                        alignItems="center"
+                        opacity={pressed ? 0.7 : 1}
+                      >
+                        <Text color="$textLight0" sx={{ _dark: { color: '$textDark0' } }} fontWeight="$medium">
+                          Cancel
+                        </Text>
+                      </Box>
+                    )}
+                  </Pressable>
+                  <Pressable
+                    flex={1}
+                    disabled={isSubmitting || groupName.trim().length < 2}
+                    onPress={handleCreate}
+                  >
+                    {({ pressed }) => (
+                      <Box
+                        bg="$primary0"
+                        sx={{ _dark: { bg: '$textDark0' } }}
+                        borderRadius={12}
+                        h={48}
+                        justifyContent="center"
+                        alignItems="center"
+                        opacity={isSubmitting || groupName.trim().length < 2 ? 0.4 : pressed ? 0.85 : 1}
+                      >
+                        <Text color="$backgroundLight0" sx={{ _dark: { color: '$backgroundDark0' } }} fontWeight="$medium">
+                          Create
+                        </Text>
+                      </Box>
+                    )}
+                  </Pressable>
+                </HStack>
+              </VStack>
+            </Box>
+          )}
+
+          {hasInvites && (
+            <VStack space="md">
+              <Text size="sm" fontWeight="$semibold" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} letterSpacing={0.5}>
+                INVITATIONS
+              </Text>
+              {pendingInvites!.map((invite) => (
+                <Box
+                  key={invite._id}
+                  bg="$cardLight"
+                  sx={{ _dark: { bg: '$cardDark', borderColor: '$borderDark0' } }}
+                  borderColor="$borderLight0"
+                  borderWidth={1}
+                  borderRadius={18}
+                  style={styles.card}
+                  p={20}
+                >
+                  <VStack space="md">
+                    <HStack space="md" alignItems="center">
+                      <Box
+                        bg="$backgroundLight100"
+                        sx={{ _dark: { bg: '$backgroundDark100' } }}
+                        borderRadius={999}
+                        w={40}
+                        h={40}
+                        justifyContent="center"
+                        alignItems="center"
+                      >
+                        <Ionicons name="mail-outline" size={20} color={isDark ? '#F8F9FA' : '#212529'} />
+                      </Box>
+                      <VStack space="xs" flex={1}>
+                        <Text size="md" fontWeight="$semibold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                          {invite.groupName}
+                        </Text>
+                        <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }}>
+                          {invite.invitedByName} invited you
+                        </Text>
+                      </VStack>
+                    </HStack>
+                    <HStack space="md">
+                      <Pressable flex={1} disabled={respondingInviteId === invite._id} onPress={() => handleAccept(invite._id)}>
+                        {({ pressed }) => (
+                          <Box
+                            bg="$primary0"
+                            sx={{ _dark: { bg: '$textDark0' } }}
+                            borderRadius={12}
+                            h={44}
+                            justifyContent="center"
+                            alignItems="center"
+                            opacity={respondingInviteId === invite._id ? 0.5 : pressed ? 0.85 : 1}
+                          >
+                            <Text color="$backgroundLight0" sx={{ _dark: { color: '$backgroundDark0' } }} fontWeight="$medium" size="sm">
+                              Accept
+                            </Text>
+                          </Box>
+                        )}
+                      </Pressable>
+                      <Pressable flex={1} disabled={respondingInviteId === invite._id} onPress={() => handleDecline(invite._id)}>
+                        {({ pressed }) => (
+                          <Box
+                            borderColor="$borderLight0"
+                            sx={{ _dark: { borderColor: '$borderDark0' } }}
+                            borderWidth={1}
+                            borderRadius={12}
+                            h={44}
+                            justifyContent="center"
+                            alignItems="center"
+                            opacity={pressed ? 0.7 : 1}
+                          >
+                            <Text color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} fontWeight="$medium" size="sm">
+                              Decline
+                            </Text>
+                          </Box>
+                        )}
+                      </Pressable>
+                    </HStack>
+                  </VStack>
+                </Box>
+              ))}
+            </VStack>
+          )}
+
+          {isLoading ? (
+            <Box py={48} alignItems="center">
+              <ActivityIndicator color={mutedIcon} />
+            </Box>
+          ) : isEmpty ? (
+            <VStack space="lg" alignItems="center" py={48}>
+              <Box
+                bg="$backgroundLight100"
+                sx={{ _dark: { bg: '$backgroundDark100' } }}
+                borderRadius={999}
+                w={72}
+                h={72}
+                justifyContent="center"
+                alignItems="center"
+              >
+                <Ionicons name="people-outline" size={34} color={mutedIcon} />
+              </Box>
+              <VStack space="xs" alignItems="center">
+                <Text size="lg" fontWeight="$semibold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                  No groups yet
+                </Text>
+                <Text size="sm" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} textAlign="center">
+                  Create a group and invite friends by name
+                </Text>
+              </VStack>
+              <Pressable onPress={openCreate}>
+                {({ pressed }) => (
+                  <Box
+                    bg="$primary0"
+                    sx={{ _dark: { bg: '$textDark0' } }}
+                    borderRadius={12}
+                    h={48}
+                    px={28}
+                    justifyContent="center"
+                    alignItems="center"
+                    opacity={pressed ? 0.85 : 1}
+                  >
+                    <Text color="$backgroundLight0" sx={{ _dark: { color: '$backgroundDark0' } }} fontWeight="$medium">
+                      Create a group
+                    </Text>
+                  </Box>
+                )}
+              </Pressable>
+            </VStack>
+          ) : groups.length > 0 ? (
+            <VStack space="md">
+              <Text size="sm" fontWeight="$semibold" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }} letterSpacing={0.5}>
+                YOUR GROUPS
+              </Text>
+              {groups.map((group) => (
+                <Pressable key={group._id} onPress={() => router.push(`/groups/${group._id}` as Href)}>
+                  {({ pressed }) => (
+                    <Box
+                      bg="$cardLight"
+                      sx={{ _dark: { bg: '$cardDark', borderColor: '$borderDark0' } }}
+                      borderColor="$borderLight0"
+                      borderWidth={1}
+                      borderRadius={18}
+                      style={styles.card}
+                      px={20}
+                      py={18}
+                      opacity={pressed ? 0.85 : 1}
+                      transform={[{ scale: pressed ? 0.98 : 1 }]}
+                    >
+                      <HStack alignItems="center" space="md">
+                        <Box
+                          bg="$backgroundLight100"
+                          sx={{ _dark: { bg: '$backgroundDark100' } }}
+                          borderRadius={12}
+                          w={44}
+                          h={44}
+                          justifyContent="center"
+                          alignItems="center"
+                        >
+                          <Ionicons name="people" size={22} color={isDark ? '#F8F9FA' : '#212529'} />
+                        </Box>
+                        <VStack space="xs" flex={1}>
+                          <Text size="lg" fontWeight="$semibold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                            {group.name}
+                          </Text>
+                          <Text size="xs" color="$textLight300" sx={{ _dark: { color: '$textDark300' } }}>
+                            {group.memberCount} member{group.memberCount === 1 ? '' : 's'}
+                          </Text>
+                        </VStack>
+                        <Ionicons name="chevron-forward" size={20} color={mutedIcon} />
+                      </HStack>
+                    </Box>
+                  )}
+                </Pressable>
+              ))}
+            </VStack>
+          ) : null}
+        </VStack>
+      </ScrollView>
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    flexGrow: 1,
+  },
+  card: {
+    shadowColor: '#000',
+    shadowOpacity: 0.04,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 1,
+  },
+});

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -3,6 +3,7 @@ import { useAuth, useUser } from '@clerk/clerk-expo';
 import { Avatar, AvatarFallbackText, AvatarImage, Box, Button, HStack, Text, VStack } from '@gluestack-ui/themed';
 import { useQuery } from 'convex/react';
 import { router } from 'expo-router';
+import { useMemo } from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -10,58 +11,29 @@ export default function ProfileScreen() {
   const insets = useSafeAreaInsets();
   const { isSignedIn, user } = useUser();
   const { signOut } = useAuth();
+  const now = useMemo(() => Date.now(), []);
+  const timezoneOffsetMinutes = useMemo(() => new Date().getTimezoneOffset(), []);
   const convexUser = useQuery(
     api.users.me,
     isSignedIn && user ? { clerkUserId: user.id } : 'skip'
   );
-  const userHistory = useQuery(
-    api.sessions.historyForUser,
-    convexUser ? { userId: convexUser._id } : 'skip'
+  const overview = useQuery(
+    api.stats.myOverview,
+    convexUser ? { now, timezoneOffsetMinutes } : 'skip'
   );
+  const userHistory = useQuery(api.stats.myHistory, convexUser ? {} : 'skip');
 
-  const completedWorkouts = userHistory?.filter((s: any) => s.status === 'completed') || [];
-  
+  const completedWorkouts = userHistory?.filter((session) => session.status === 'completed') || [];
+
   const last7Days = Array.from({ length: 7 }, (_, i) => {
-    const date = new Date();
+    const date = new Date(now);
     date.setDate(date.getDate() - (6 - i));
     return date;
   });
 
-  const workoutsPerDay = last7Days.map(date => {
-    const dateStr = date.toDateString();
-    return completedWorkouts.filter((session: any) => 
-      new Date(session.completedAt).toDateString() === dateStr
-    ).length;
-  });
-
-  const thisWeekWorkouts = completedWorkouts.filter((session: any) => {
-    const sessionDate = new Date(session.completedAt);
-    const weekAgo = new Date();
-    weekAgo.setDate(weekAgo.getDate() - 7);
-    return sessionDate >= weekAgo;
-  }).length;
-
-  const workoutDays = new Set(
-    completedWorkouts.map((session: any) => {
-      const d = new Date(session.completedAt);
-      d.setHours(0, 0, 0, 0);
-      return d.getTime();
-    })
-  );
-
-  const sortedCompleted = [...completedWorkouts].sort(
-    (a: any, b: any) => (b.completedAt || 0) - (a.completedAt || 0)
-  );
-
-  let currentStreak = 0;
-  if (sortedCompleted.length > 0) {
-    const cursor = new Date(sortedCompleted[0].completedAt ?? 0);
-    cursor.setHours(0, 0, 0, 0);
-    while (workoutDays.has(cursor.getTime())) {
-      currentStreak += 1;
-      cursor.setDate(cursor.getDate() - 1);
-    }
-  }
+  const thisWeekWorkouts = overview?.thisWeekWorkouts ?? 0;
+  const currentStreak = overview?.currentStreak ?? 0;
+  const workoutsPerDay = overview?.workoutsPerDay ?? Array.from({ length: 7 }, () => 0);
 
 
   return (

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,6 +1,9 @@
+import { api } from '@/convex/_generated/api';
 import { useThemeMode } from '@/hooks/useThemeMode';
 import { useWeightUnit } from '@/hooks/useWeightUnit';
+import { useAuth } from '@clerk/clerk-expo';
 import { Box, HStack, Pressable, Text, VStack } from '@gluestack-ui/themed';
+import { useMutation, useQuery } from 'convex/react';
 import { ScrollView, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -17,8 +20,29 @@ const weightUnitOptions = [
 
 export default function SettingsScreen() {
   const insets = useSafeAreaInsets();
+  const { isSignedIn } = useAuth();
   const { themeMode, setThemeMode } = useThemeMode();
   const { weightUnit, setWeightUnit } = useWeightUnit();
+  const notificationSettings = useQuery(api.notifications.getSettings, isSignedIn ? {} : 'skip');
+  const updateNotificationPrefs = useMutation(api.notifications.updateNotificationPrefs);
+
+  const toggleGroupWorkoutNotifications = async () => {
+    if (!notificationSettings) {
+      return;
+    }
+    await updateNotificationPrefs({
+      notifyOnGroupWorkout: !notificationSettings.notifyOnGroupWorkout,
+    });
+  };
+
+  const toggleWeeklyRecapNotifications = async () => {
+    if (!notificationSettings) {
+      return;
+    }
+    await updateNotificationPrefs({
+      notifyWeeklyRecap: !notificationSettings.notifyWeeklyRecap,
+    });
+  };
 
   return (
     <Box 
@@ -260,6 +284,134 @@ export default function SettingsScreen() {
                 </VStack>
               </VStack>
             </Box>
+
+            {isSignedIn && (
+              <Box
+                bg="$cardLight"
+                sx={{ _dark: { bg: '$cardDark', borderColor: '$borderDark0' } }}
+                borderColor="$borderLight0"
+                borderWidth={1}
+                borderRadius={16}
+                p={24}
+              >
+                <VStack space="xl">
+                  <VStack space="sm">
+                    <Text size="lg" fontWeight="$semibold" color="$textLight0" sx={{ _dark: { color: '$textDark0' } }}>
+                      Group Notifications
+                    </Text>
+                    <Text size="sm" color="$textLight200" sx={{ _dark: { color: '$textDark200' } }}>
+                      Stay in the loop with your training groups
+                    </Text>
+                  </VStack>
+
+                  <VStack space="md">
+                    <Pressable onPress={toggleGroupWorkoutNotifications}>
+                      {({ pressed }) => (
+                        <Box
+                          bg={notificationSettings?.notifyOnGroupWorkout ? '$primary0' : 'transparent'}
+                          sx={
+                            notificationSettings?.notifyOnGroupWorkout
+                              ? { _dark: { bg: '$textDark0', borderColor: '$textDark0' } }
+                              : { _dark: { borderColor: '$borderDark0' } }
+                          }
+                          borderColor={notificationSettings?.notifyOnGroupWorkout ? '$primary0' : '$borderLight0'}
+                          borderWidth={2}
+                          borderRadius={12}
+                          p={16}
+                          opacity={pressed ? 0.85 : 1}
+                        >
+                          <HStack justifyContent="space-between" alignItems="center">
+                            <VStack space="xs" flex={1}>
+                              <Text
+                                size="md"
+                                fontWeight="$medium"
+                                color={notificationSettings?.notifyOnGroupWorkout ? '$backgroundLight0' : '$textLight0'}
+                                sx={
+                                  notificationSettings?.notifyOnGroupWorkout
+                                    ? { _dark: { color: '$backgroundDark0' } }
+                                    : { _dark: { color: '$textDark0' } }
+                                }
+                              >
+                                Workout finished
+                              </Text>
+                              <Text
+                                size="xs"
+                                color={notificationSettings?.notifyOnGroupWorkout ? '$backgroundLight0' : '$textLight300'}
+                                sx={
+                                  notificationSettings?.notifyOnGroupWorkout
+                                    ? { _dark: { color: '$backgroundDark0' } }
+                                    : { _dark: { color: '$textDark300' } }
+                                }
+                                opacity={0.9}
+                              >
+                                Notify when a group member completes a workout
+                              </Text>
+                            </VStack>
+                            {notificationSettings?.notifyOnGroupWorkout && (
+                              <Text size="lg" color="$backgroundLight0" sx={{ _dark: { color: '$backgroundDark0' } }} fontWeight="$bold">
+                                ✓
+                              </Text>
+                            )}
+                          </HStack>
+                        </Box>
+                      )}
+                    </Pressable>
+
+                    <Pressable onPress={toggleWeeklyRecapNotifications}>
+                      {({ pressed }) => (
+                        <Box
+                          bg={notificationSettings?.notifyWeeklyRecap ? '$primary0' : 'transparent'}
+                          sx={
+                            notificationSettings?.notifyWeeklyRecap
+                              ? { _dark: { bg: '$textDark0', borderColor: '$textDark0' } }
+                              : { _dark: { borderColor: '$borderDark0' } }
+                          }
+                          borderColor={notificationSettings?.notifyWeeklyRecap ? '$primary0' : '$borderLight0'}
+                          borderWidth={2}
+                          borderRadius={12}
+                          p={16}
+                          opacity={pressed ? 0.85 : 1}
+                        >
+                          <HStack justifyContent="space-between" alignItems="center">
+                            <VStack space="xs" flex={1}>
+                              <Text
+                                size="md"
+                                fontWeight="$medium"
+                                color={notificationSettings?.notifyWeeklyRecap ? '$backgroundLight0' : '$textLight0'}
+                                sx={
+                                  notificationSettings?.notifyWeeklyRecap
+                                    ? { _dark: { color: '$backgroundDark0' } }
+                                    : { _dark: { color: '$textDark0' } }
+                                }
+                              >
+                                Weekly recap
+                              </Text>
+                              <Text
+                                size="xs"
+                                color={notificationSettings?.notifyWeeklyRecap ? '$backgroundLight0' : '$textLight300'}
+                                sx={
+                                  notificationSettings?.notifyWeeklyRecap
+                                    ? { _dark: { color: '$backgroundDark0' } }
+                                    : { _dark: { color: '$textDark300' } }
+                                }
+                                opacity={0.9}
+                              >
+                                Sunday evening summary with the weekly leader
+                              </Text>
+                            </VStack>
+                            {notificationSettings?.notifyWeeklyRecap && (
+                              <Text size="lg" color="$backgroundLight0" sx={{ _dark: { color: '$backgroundDark0' } }} fontWeight="$bold">
+                                ✓
+                              </Text>
+                            )}
+                          </HStack>
+                        </Box>
+                      )}
+                    </Pressable>
+                  </VStack>
+                </VStack>
+              </Box>
+            )}
 
           </VStack>
         </VStack>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,9 @@
 import ActiveSessionResume from '@/components/ActiveSessionResume';
+import { AppToastProvider } from '@/components/AppToast';
 import AuthSync from '@/components/AuthSync';
 import WorkoutMutationSync from '@/components/WorkoutMutationSync';
 import WorkoutSummaryPrefetch from '@/components/WorkoutSummaryPrefetch';
+import { usePushNotifications } from '@/hooks/usePushNotifications';
 import { ClerkProvider, useAuth } from '@clerk/clerk-expo';
 import { tokenCache } from '@clerk/clerk-expo/token-cache';
 import { Box, Button, GluestackUIProvider, Text, VStack } from '@gluestack-ui/themed';
@@ -82,8 +84,10 @@ export default function RootLayout() {
     <ClerkProvider publishableKey={publishableKey} tokenCache={tokenCache}>
       <ConvexProviderWithClerk client={convexClient} useAuth={useAuth}>
         <GluestackUIProvider config={theme} colorMode={effectiveColorScheme === 'dark' ? 'dark' : 'light'}>
+          <AppToastProvider>
           <ThemeProvider value={effectiveColorScheme === 'dark' ? DarkTheme : DefaultTheme}>
             <AuthSync />
+            <PushNotificationRegistration />
             <ActiveSessionResume />
             <WorkoutMutationSync />
             <WorkoutSummaryPrefetch />
@@ -144,8 +148,14 @@ export default function RootLayout() {
             </Stack>
             <StatusBar style={effectiveColorScheme === 'dark' ? 'light' : 'dark'} />
           </ThemeProvider>
+          </AppToastProvider>
         </GluestackUIProvider>
       </ConvexProviderWithClerk>
     </ClerkProvider>
   );
+}
+
+function PushNotificationRegistration() {
+  usePushNotifications();
+  return null;
 }

--- a/components/AppToast.tsx
+++ b/components/AppToast.tsx
@@ -1,0 +1,95 @@
+import { Box, Text } from '@gluestack-ui/themed';
+import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from 'react';
+import { Animated, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+type ToastContextValue = {
+  showToast: (message: string) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function AppToastProvider({ children }: { children: ReactNode }) {
+  const insets = useSafeAreaInsets();
+  const [message, setMessage] = useState<string | null>(null);
+  const opacity = useRef(new Animated.Value(0)).current;
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showToast = useCallback(
+    (text: string) => {
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+      }
+
+      setMessage(text);
+      opacity.setValue(0);
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }).start();
+
+      hideTimeoutRef.current = setTimeout(() => {
+        Animated.timing(opacity, {
+          toValue: 0,
+          duration: 200,
+          useNativeDriver: true,
+        }).start(({ finished }) => {
+          if (finished) {
+            setMessage(null);
+          }
+        });
+      }, 2400);
+    },
+    [opacity]
+  );
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {message ? (
+        <Animated.View
+          pointerEvents="none"
+          style={[styles.container, { bottom: insets.bottom + 100, opacity }]}
+        >
+          <Box
+            bg="$primary0"
+            sx={{ _dark: { bg: '$textDark0' } }}
+            px={20}
+            py={14}
+            borderRadius={12}
+            maxWidth="90%"
+          >
+            <Text
+              color="$backgroundLight0"
+              sx={{ _dark: { color: '$backgroundDark0' } }}
+              size="sm"
+              fontWeight="$medium"
+              textAlign="center"
+            >
+              {message}
+            </Text>
+          </Box>
+        </Animated.View>
+      ) : null}
+    </ToastContext.Provider>
+  );
+}
+
+export function useAppToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useAppToast must be used within AppToastProvider');
+  }
+  return context;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    zIndex: 9999,
+  },
+});

--- a/components/AuthSync.tsx
+++ b/components/AuthSync.tsx
@@ -20,15 +20,14 @@ export default function AuthSync() {
         await getOrCreate({
           clerkUserId: user.id,
           displayName: user.fullName ?? user.firstName ?? user.username ?? undefined,
+          imageUrl: user.imageUrl ?? undefined,
         });
         lastSyncedId.current = user.id;
       } catch {}
     };
-    const timer = setTimeout(run, 1000);
-    return () => clearTimeout(timer);
+
+    void run();
   }, [isSignedIn, user, getOrCreate, convexLoading, convexAuthenticated]);
 
   return null;
 }
-
-

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -15,6 +15,10 @@ type IconSymbolName = keyof typeof MAPPING;
  */
 const MAPPING = {
   'house.fill': 'home',
+  'dumbbell.fill': 'fitness-center',
+  'person.2.fill': 'groups',
+  'person.circle.fill': 'account-circle',
+  'gearshape.fill': 'settings',
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,10 +13,18 @@ import type {
   FilterApi,
   FunctionReference,
 } from "convex/server";
+import type * as crons from "../crons.js";
 import type * as exercises from "../exercises.js";
+import type * as groups from "../groups.js";
+import type * as leaderboard from "../leaderboard.js";
+import type * as lib_auth from "../lib/auth.js";
+import type * as lib_stats from "../lib/stats.js";
 import type * as media from "../media.js";
+import type * as notifications from "../notifications.js";
+import type * as notificationsActions from "../notificationsActions.js";
 import type * as seedData from "../seedData.js";
 import type * as sessions from "../sessions.js";
+import type * as stats from "../stats.js";
 import type * as templates from "../templates.js";
 import type * as users from "../users.js";
 
@@ -29,10 +37,18 @@ import type * as users from "../users.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  crons: typeof crons;
   exercises: typeof exercises;
+  groups: typeof groups;
+  leaderboard: typeof leaderboard;
+  "lib/auth": typeof lib_auth;
+  "lib/stats": typeof lib_stats;
   media: typeof media;
+  notifications: typeof notifications;
+  notificationsActions: typeof notificationsActions;
   seedData: typeof seedData;
   sessions: typeof sessions;
+  stats: typeof stats;
   templates: typeof templates;
   users: typeof users;
 }>;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,12 @@
+import { cronJobs } from 'convex/server';
+import { internal } from './_generated/api';
+
+const crons = cronJobs();
+
+crons.hourly(
+  'weekly group recap',
+  { minuteUTC: 0 },
+  internal.notifications.sendWeeklyRecaps
+);
+
+export default crons;

--- a/convex/groups.ts
+++ b/convex/groups.ts
@@ -1,0 +1,485 @@
+import { v } from 'convex/values';
+import { internal } from './_generated/api';
+import { mutation, query } from './_generated/server';
+import { ensureCurrentUser, getCurrentUser, requireGroupMembership } from './lib/auth';
+
+const groupSummaryValidator = v.object({
+  _id: v.id('groups'),
+  name: v.string(),
+  memberCount: v.number(),
+  role: v.union(v.literal('owner'), v.literal('member')),
+  createdAt: v.number(),
+});
+
+const pendingInviteValidator = v.object({
+  _id: v.id('groupInvitations'),
+  groupId: v.id('groups'),
+  groupName: v.string(),
+  invitedByName: v.string(),
+  createdAt: v.number(),
+});
+
+const searchResultValidator = v.object({
+  userId: v.id('users'),
+  displayName: v.string(),
+});
+
+const sentInviteValidator = v.object({
+  _id: v.id('groupInvitations'),
+  displayName: v.string(),
+  createdAt: v.number(),
+});
+
+export const create = mutation({
+  args: { name: v.string() },
+  returns: v.object({
+    groupId: v.id('groups'),
+  }),
+  handler: async (ctx, { name }) => {
+    const user = await ensureCurrentUser(ctx);
+    const trimmedName = name.trim();
+    if (trimmedName.length < 2) {
+      throw new Error('Group name must be at least 2 characters');
+    }
+
+    const now = Date.now();
+    const groupId = await ctx.db.insert('groups', {
+      name: trimmedName,
+      createdByUserId: user._id,
+      createdAt: now,
+    });
+
+    await ctx.db.insert('groupMembers', {
+      groupId,
+      userId: user._id,
+      role: 'owner',
+      joinedAt: now,
+    });
+
+    return { groupId };
+  },
+});
+
+export const searchUsersForInvite = query({
+  args: {
+    groupId: v.id('groups'),
+    query: v.string(),
+  },
+  returns: v.array(searchResultValidator),
+  handler: async (ctx, { groupId, query: searchQuery }) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return [];
+    }
+
+    await requireGroupMembership(ctx, groupId, user._id);
+
+    const trimmedQuery = searchQuery.trim().toLowerCase();
+    if (trimmedQuery.length < 2) {
+      return [];
+    }
+
+    const members = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_group', (q) => q.eq('groupId', groupId))
+      .collect();
+    const memberIds = new Set(members.map((member) => String(member.userId)));
+
+    const pendingInvites = await ctx.db
+      .query('groupInvitations')
+      .withIndex('by_group_status', (q) => q.eq('groupId', groupId).eq('status', 'pending'))
+      .collect();
+    const pendingUserIds = new Set(pendingInvites.map((invite) => String(invite.invitedUserId)));
+
+    const allUsers = await ctx.db.query('users').collect();
+
+    return allUsers
+      .filter((candidate) => {
+        if (String(candidate._id) === String(user._id)) {
+          return false;
+        }
+        if (memberIds.has(String(candidate._id))) {
+          return false;
+        }
+        if (pendingUserIds.has(String(candidate._id))) {
+          return false;
+        }
+        const displayName = (candidate.displayName ?? 'Athlete').toLowerCase();
+        return displayName.includes(trimmedQuery);
+      })
+      .slice(0, 8)
+      .map((candidate) => ({
+        userId: candidate._id,
+        displayName: candidate.displayName ?? 'Athlete',
+      }));
+  },
+});
+
+export const sendInvite = mutation({
+  args: {
+    groupId: v.id('groups'),
+    userId: v.id('users'),
+  },
+  returns: v.id('groupInvitations'),
+  handler: async (ctx, { groupId, userId }) => {
+    const user = await ensureCurrentUser(ctx);
+    await requireGroupMembership(ctx, groupId, user._id);
+
+    if (userId === user._id) {
+      throw new Error('You cannot invite yourself');
+    }
+
+    const invitedUser = await ctx.db.get(userId);
+    if (!invitedUser) {
+      throw new Error('User not found');
+    }
+
+    const existingMembership = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_group_and_user', (q) => q.eq('groupId', groupId).eq('userId', userId))
+      .first();
+    if (existingMembership) {
+      throw new Error('User is already in this group');
+    }
+
+    const existingInvite = await ctx.db
+      .query('groupInvitations')
+      .withIndex('by_group_and_invited_user', (q) => q.eq('groupId', groupId).eq('invitedUserId', userId))
+      .first();
+
+    if (existingInvite?.status === 'pending') {
+      throw new Error('Invite already pending');
+    }
+
+    const now = Date.now();
+    let inviteId;
+
+    if (existingInvite) {
+      await ctx.db.patch(existingInvite._id, {
+        invitedByUserId: user._id,
+        status: 'pending',
+        createdAt: now,
+        respondedAt: undefined,
+      });
+      inviteId = existingInvite._id;
+    } else {
+      inviteId = await ctx.db.insert('groupInvitations', {
+        groupId,
+        invitedUserId: userId,
+        invitedByUserId: user._id,
+        status: 'pending',
+        createdAt: now,
+      });
+    }
+
+    await ctx.scheduler.runAfter(0, internal.notifications.notifyGroupInvite, {
+      invitationId: inviteId,
+    });
+
+    return inviteId;
+  },
+});
+
+export const listMyPendingInvites = query({
+  args: {},
+  returns: v.array(pendingInviteValidator),
+  handler: async (ctx) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return [];
+    }
+
+    const invites = await ctx.db
+      .query('groupInvitations')
+      .withIndex('by_invited_user_status', (q) => q.eq('invitedUserId', user._id).eq('status', 'pending'))
+      .collect();
+
+    const details = await Promise.all(
+      invites.map(async (invite) => {
+        const group = await ctx.db.get(invite.groupId);
+        const inviter = await ctx.db.get(invite.invitedByUserId);
+        if (!group) {
+          return null;
+        }
+
+        return {
+          _id: invite._id,
+          groupId: invite.groupId,
+          groupName: group.name,
+          invitedByName: inviter?.displayName ?? 'Someone',
+          createdAt: invite.createdAt,
+        };
+      })
+    );
+
+    return details
+      .filter((invite): invite is NonNullable<typeof invite> => invite !== null)
+      .sort((a, b) => b.createdAt - a.createdAt);
+  },
+});
+
+export const listPendingInvitesForGroup = query({
+  args: { groupId: v.id('groups') },
+  returns: v.array(sentInviteValidator),
+  handler: async (ctx, { groupId }) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return [];
+    }
+
+    await requireGroupMembership(ctx, groupId, user._id);
+
+    const invites = await ctx.db
+      .query('groupInvitations')
+      .withIndex('by_group_status', (q) => q.eq('groupId', groupId).eq('status', 'pending'))
+      .collect();
+
+    const details = await Promise.all(
+      invites.map(async (invite) => {
+        const invitedUser = await ctx.db.get(invite.invitedUserId);
+        return {
+          _id: invite._id,
+          displayName: invitedUser?.displayName ?? 'Athlete',
+          createdAt: invite.createdAt,
+        };
+      })
+    );
+
+    return details.sort((a, b) => b.createdAt - a.createdAt);
+  },
+});
+
+export const acceptInvite = mutation({
+  args: { invitationId: v.id('groupInvitations') },
+  returns: v.id('groups'),
+  handler: async (ctx, { invitationId }) => {
+    const user = await ensureCurrentUser(ctx);
+    const invite = await ctx.db.get(invitationId);
+
+    if (!invite || invite.invitedUserId !== user._id) {
+      throw new Error('Invitation not found');
+    }
+    if (invite.status !== 'pending') {
+      throw new Error('Invitation is no longer pending');
+    }
+
+    const existingMembership = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_group_and_user', (q) => q.eq('groupId', invite.groupId).eq('userId', user._id))
+      .first();
+
+    if (!existingMembership) {
+      await ctx.db.insert('groupMembers', {
+        groupId: invite.groupId,
+        userId: user._id,
+        role: 'member',
+        joinedAt: Date.now(),
+      });
+    }
+
+    await ctx.db.patch(invitationId, {
+      status: 'accepted',
+      respondedAt: Date.now(),
+    });
+
+    return invite.groupId;
+  },
+});
+
+export const declineInvite = mutation({
+  args: { invitationId: v.id('groupInvitations') },
+  returns: v.null(),
+  handler: async (ctx, { invitationId }) => {
+    const user = await ensureCurrentUser(ctx);
+    const invite = await ctx.db.get(invitationId);
+
+    if (!invite || invite.invitedUserId !== user._id) {
+      throw new Error('Invitation not found');
+    }
+    if (invite.status !== 'pending') {
+      throw new Error('Invitation is no longer pending');
+    }
+
+    await ctx.db.patch(invitationId, {
+      status: 'declined',
+      respondedAt: Date.now(),
+    });
+
+    return null;
+  },
+});
+
+export const leave = mutation({
+  args: { groupId: v.id('groups') },
+  returns: v.null(),
+  handler: async (ctx, { groupId }) => {
+    const user = await ensureCurrentUser(ctx);
+    const membership = await requireGroupMembership(ctx, groupId, user._id);
+
+    const members = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_group', (q) => q.eq('groupId', groupId))
+      .collect();
+
+    if (members.length <= 1) {
+      const pendingInvites = await ctx.db
+        .query('groupInvitations')
+        .withIndex('by_group_status', (q) => q.eq('groupId', groupId).eq('status', 'pending'))
+        .collect();
+      for (const invite of pendingInvites) {
+        await ctx.db.delete(invite._id);
+      }
+      for (const member of members) {
+        await ctx.db.delete(member._id);
+      }
+      await ctx.db.delete(groupId);
+      return null;
+    }
+
+    await ctx.db.delete(membership._id);
+
+    if (membership.role === 'owner') {
+      const remainingMembers = members
+        .filter((member) => member._id !== membership._id)
+        .sort((a, b) => a.joinedAt - b.joinedAt);
+      const nextOwner = remainingMembers[0];
+      if (nextOwner) {
+        await ctx.db.patch(nextOwner._id, { role: 'owner' });
+      }
+    }
+
+    return null;
+  },
+});
+
+export const listMine = query({
+  args: {},
+  returns: v.array(groupSummaryValidator),
+  handler: async (ctx) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return [];
+    }
+
+    const memberships = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_user', (q) => q.eq('userId', user._id))
+      .collect();
+
+    const groups = await Promise.all(
+      memberships.map(async (membership) => {
+        const group = await ctx.db.get(membership.groupId);
+        if (!group) {
+          return null;
+        }
+
+        const memberCount = (
+          await ctx.db
+            .query('groupMembers')
+            .withIndex('by_group', (q) => q.eq('groupId', group._id))
+            .collect()
+        ).length;
+
+        return {
+          _id: group._id,
+          name: group.name,
+          memberCount,
+          role: membership.role,
+          createdAt: group.createdAt,
+        };
+      })
+    );
+
+    return groups
+      .filter((group): group is NonNullable<typeof group> => group !== null)
+      .sort((a, b) => b.createdAt - a.createdAt);
+  },
+});
+
+export const getGroup = query({
+  args: { groupId: v.id('groups') },
+  returns: v.union(
+    v.object({
+      _id: v.id('groups'),
+      name: v.string(),
+      memberCount: v.number(),
+      role: v.union(v.literal('owner'), v.literal('member')),
+      createdAt: v.number(),
+    }),
+    v.null()
+  ),
+  handler: async (ctx, { groupId }) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return null;
+    }
+
+    const membership = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_group_and_user', (q) => q.eq('groupId', groupId).eq('userId', user._id))
+      .first();
+
+    if (!membership) {
+      return null;
+    }
+
+    const group = await ctx.db.get(groupId);
+    if (!group) {
+      return null;
+    }
+
+    const memberCount = (
+      await ctx.db
+        .query('groupMembers')
+        .withIndex('by_group', (q) => q.eq('groupId', groupId))
+        .collect()
+    ).length;
+
+    return {
+      _id: group._id,
+      name: group.name,
+      memberCount,
+      role: membership.role,
+      createdAt: group.createdAt,
+    };
+  },
+});
+
+export const getMembers = query({
+  args: { groupId: v.id('groups') },
+  returns: v.array(
+    v.object({
+      userId: v.id('users'),
+      displayName: v.string(),
+      role: v.union(v.literal('owner'), v.literal('member')),
+      joinedAt: v.number(),
+    })
+  ),
+  handler: async (ctx, { groupId }) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return [];
+    }
+
+    await requireGroupMembership(ctx, groupId, user._id);
+
+    const members = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_group', (q) => q.eq('groupId', groupId))
+      .collect();
+
+    const memberDetails = await Promise.all(
+      members.map(async (member) => {
+        const memberUser = await ctx.db.get(member.userId);
+        return {
+          userId: member.userId,
+          displayName: memberUser?.displayName ?? 'Athlete',
+          role: member.role,
+          joinedAt: member.joinedAt,
+        };
+      })
+    );
+
+    return memberDetails.sort((a, b) => a.joinedAt - b.joinedAt);
+  },
+});

--- a/convex/leaderboard.ts
+++ b/convex/leaderboard.ts
@@ -1,0 +1,280 @@
+import { v } from 'convex/values';
+import type { Id } from './_generated/dataModel';
+import { query } from './_generated/server';
+import { getCurrentUser, requireGroupMembership } from './lib/auth';
+import {
+  computeActivityExercises,
+  computeMetricDetail,
+  computeMetricValue,
+  countDoneSets,
+  deriveWorkoutTitle,
+  getCompletedSessions,
+  resolveTimezoneOffsetMinutes,
+  type LeaderboardMetric,
+} from './lib/stats';
+
+const metricValidator = v.union(
+  v.literal('prsThisMonth'),
+  v.literal('workoutsThisWeek'),
+  v.literal('currentStreak')
+);
+
+const detailValidator = v.union(
+  v.object({
+    type: v.literal('prsThisMonth'),
+    prs: v.array(
+      v.object({
+        exerciseName: v.string(),
+        weight: v.number(),
+        completedAt: v.number(),
+        isPrimary: v.boolean(),
+      })
+    ),
+  }),
+  v.object({
+    type: v.literal('workoutsThisWeek'),
+    workouts: v.array(
+      v.object({
+        completedAt: v.number(),
+        title: v.string(),
+      })
+    ),
+  }),
+  v.object({
+    type: v.literal('currentStreak'),
+    lastWorkoutAt: v.union(v.number(), v.null()),
+    workedToday: v.boolean(),
+  })
+);
+
+const leaderboardEntryValidator = v.object({
+  userId: v.id('users'),
+  displayName: v.string(),
+  imageUrl: v.union(v.string(), v.null()),
+  value: v.number(),
+  rank: v.number(),
+  isCurrentUser: v.boolean(),
+  detail: detailValidator,
+});
+
+export const forGroup = query({
+  args: {
+    groupId: v.id('groups'),
+    metric: metricValidator,
+    periodStart: v.number(),
+    timezoneOffsetMinutes: v.number(),
+  },
+  returns: v.array(leaderboardEntryValidator),
+  handler: async (ctx, { groupId, metric, periodStart, timezoneOffsetMinutes }) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return [];
+    }
+
+    await requireGroupMembership(ctx, groupId, user._id);
+
+    const members = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_group', (q) => q.eq('groupId', groupId))
+      .collect();
+
+    const memberSessions = await Promise.all(
+      members.map(async (member) => ({
+        member,
+        sessions: await ctx.db
+          .query('sessions')
+          .withIndex('by_user_started', (q) => q.eq('userId', member.userId))
+          .collect(),
+        notificationSettings: await ctx.db
+          .query('userNotificationSettings')
+          .withIndex('by_user', (q) => q.eq('userId', member.userId))
+          .unique(),
+      }))
+    );
+
+    const templateIds = new Set<string>();
+    for (const { sessions } of memberSessions) {
+      for (const session of sessions) {
+        if (session.templateId) {
+          templateIds.add(String(session.templateId));
+        }
+      }
+    }
+
+    const templateNamesById = new Map<string, string>();
+    for (const templateId of templateIds) {
+      const template = await ctx.db.get(templateId as Id<'templates'>);
+      if (template) {
+        templateNamesById.set(String(template._id), template.name);
+      }
+    }
+
+    const entries = memberSessions.map(({ member, sessions, notificationSettings }) => {
+      const leaderboardMetric = metric as LeaderboardMetric;
+      const memberTimezoneOffsetMinutes = resolveTimezoneOffsetMinutes(periodStart, {
+        timezone: notificationSettings?.timezone,
+        viewerTimezoneOffsetMinutes: timezoneOffsetMinutes,
+        isViewer: member.userId === user._id,
+      });
+
+      return {
+        userId: member.userId,
+        joinedAt: member.joinedAt,
+        value: computeMetricValue(
+          sessions,
+          leaderboardMetric,
+          periodStart,
+          memberTimezoneOffsetMinutes
+        ),
+        detail: computeMetricDetail(
+          sessions,
+          leaderboardMetric,
+          periodStart,
+          templateNamesById,
+          memberTimezoneOffsetMinutes
+        ),
+      };
+    });
+
+    const entriesWithUsers = await Promise.all(
+      entries.map(async (entry) => {
+        const memberUser = await ctx.db.get(entry.userId);
+        return {
+          userId: entry.userId,
+          displayName: memberUser?.displayName ?? 'Athlete',
+          imageUrl: memberUser?.imageUrl ?? null,
+          joinedAt: entry.joinedAt,
+          value: entry.value,
+          detail: entry.detail,
+        };
+      })
+    );
+    entriesWithUsers.sort((a, b) => {
+      if (b.value !== a.value) {
+        return b.value - a.value;
+      }
+      if (a.joinedAt !== b.joinedAt) {
+        return a.joinedAt - b.joinedAt;
+      }
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+    let rank = 0;
+    let lastValue: number | null = null;
+
+    return entriesWithUsers.map((entry, index) => {
+      if (lastValue === null || entry.value !== lastValue) {
+        rank = index + 1;
+        lastValue = entry.value;
+      }
+
+      return {
+        userId: entry.userId,
+        displayName: entry.displayName,
+        imageUrl: entry.imageUrl,
+        value: entry.value,
+        rank,
+        isCurrentUser: entry.userId === user._id,
+        detail: entry.detail,
+      };
+    });
+  },
+});
+
+const activityItemValidator = v.object({
+  sessionId: v.id('sessions'),
+  userId: v.id('users'),
+  displayName: v.string(),
+  imageUrl: v.union(v.string(), v.null()),
+  isCurrentUser: v.boolean(),
+  completedAt: v.number(),
+  title: v.string(),
+  setCount: v.number(),
+  exercises: v.array(
+    v.object({
+      exerciseName: v.string(),
+      weight: v.number(),
+      reps: v.number(),
+      isPrimary: v.boolean(),
+      weighted: v.boolean(),
+    })
+  ),
+});
+
+export const recentActivity = query({
+  args: {
+    groupId: v.id('groups'),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(activityItemValidator),
+  handler: async (ctx, { groupId, limit }) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return [];
+    }
+
+    await requireGroupMembership(ctx, groupId, user._id);
+
+    const members = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_group', (q) => q.eq('groupId', groupId))
+      .collect();
+
+    const memberSessions = await Promise.all(
+      members.map(async (member) => ({
+        member,
+        sessions: await ctx.db
+          .query('sessions')
+          .withIndex('by_user_started', (q) => q.eq('userId', member.userId))
+          .collect(),
+      }))
+    );
+
+    const userInfoById = new Map<string, { displayName: string; imageUrl: string | null }>();
+    await Promise.all(
+      members.map(async (member) => {
+        const memberUser = await ctx.db.get(member.userId);
+        userInfoById.set(String(member.userId), {
+          displayName: memberUser?.displayName ?? 'Athlete',
+          imageUrl: memberUser?.imageUrl ?? null,
+        });
+      })
+    );
+
+    const templateIds = new Set<string>();
+    for (const { sessions } of memberSessions) {
+      for (const session of sessions) {
+        if (session.templateId) {
+          templateIds.add(String(session.templateId));
+        }
+      }
+    }
+
+    const templateNamesById = new Map<string, string>();
+    for (const templateId of templateIds) {
+      const template = await ctx.db.get(templateId as Id<'templates'>);
+      if (template) {
+        templateNamesById.set(String(template._id), template.name);
+      }
+    }
+
+    const items = memberSessions.flatMap(({ member, sessions }) => {
+      const info = userInfoById.get(String(member.userId));
+      return getCompletedSessions(sessions).map((session) => ({
+        sessionId: session._id,
+        userId: member.userId,
+        displayName: info?.displayName ?? 'Athlete',
+        imageUrl: info?.imageUrl ?? null,
+        isCurrentUser: member.userId === user._id,
+        completedAt: session.completedAt ?? 0,
+        title: deriveWorkoutTitle(session, templateNamesById),
+        setCount: countDoneSets(session),
+        exercises: computeActivityExercises(session),
+      }));
+    });
+
+    items.sort((a, b) => b.completedAt - a.completedAt);
+
+    return items.slice(0, limit ?? 30);
+  },
+});

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -1,0 +1,63 @@
+import type { MutationCtx, QueryCtx } from '../_generated/server';
+import type { Doc, Id } from '../_generated/dataModel';
+
+type AuthCtx = QueryCtx | MutationCtx;
+
+export async function getCurrentUser(ctx: AuthCtx): Promise<Doc<'users'> | null> {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity?.subject) {
+    return null;
+  }
+
+  return await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', (q) => q.eq('clerkUserId', identity.subject))
+    .unique();
+}
+
+export async function ensureCurrentUser(ctx: MutationCtx): Promise<Doc<'users'>> {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity?.subject) {
+    throw new Error('Not authenticated');
+  }
+
+  const existing = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', (q) => q.eq('clerkUserId', identity.subject))
+    .unique();
+
+  if (existing) {
+    return existing;
+  }
+
+  const now = Date.now();
+  const userId = await ctx.db.insert('users', {
+    clerkUserId: identity.subject,
+    displayName: identity.name ?? undefined,
+    createdAt: now,
+  });
+
+  const user = await ctx.db.get(userId);
+  if (!user) {
+    throw new Error('Failed to create user');
+  }
+
+  return user;
+}
+
+export async function requireGroupMembership(
+  ctx: AuthCtx,
+  groupId: Id<'groups'>,
+  userId: Id<'users'>
+): Promise<Doc<'groupMembers'>> {
+  const membership = await ctx.db
+    .query('groupMembers')
+    .withIndex('by_group_and_user', (q) => q.eq('groupId', groupId).eq('userId', userId))
+    .unique();
+
+  if (!membership) {
+    throw new Error('Not a member of this group');
+  }
+
+  return membership;
+}

--- a/convex/lib/stats.ts
+++ b/convex/lib/stats.ts
@@ -1,0 +1,462 @@
+import type { Doc } from '../_generated/dataModel';
+
+type SessionDoc = Doc<'sessions'>;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MS_PER_WEEK = 7 * MS_PER_DAY;
+const MS_PER_MONTH = 30 * MS_PER_DAY;
+const MS_PER_MINUTE = 60 * 1000;
+
+function localDateKey(timestampMs: number, timezoneOffsetMinutes: number): string {
+  const localMs = timestampMs - timezoneOffsetMinutes * MS_PER_MINUTE;
+  const date = new Date(localMs);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function offsetMinutesForTimezone(timestampMs: number, timezone: string): number {
+  try {
+    const date = new Date(timestampMs);
+    const utcMs = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' })).getTime();
+    const tzMs = new Date(date.toLocaleString('en-US', { timeZone: timezone })).getTime();
+    return (utcMs - tzMs) / MS_PER_MINUTE;
+  } catch {
+    return 0;
+  }
+}
+
+function localDateKeyWithOffset(
+  referenceMs: number,
+  timezoneOffsetMinutes: number,
+  dayOffset: number
+): string {
+  const localMs = referenceMs - timezoneOffsetMinutes * MS_PER_MINUTE;
+  const date = new Date(localMs);
+  date.setUTCDate(date.getUTCDate() + dayOffset);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function resolveTimezoneOffsetMinutes(
+  timestampMs: number,
+  options: {
+    timezone?: string;
+    viewerTimezoneOffsetMinutes?: number;
+    isViewer?: boolean;
+  }
+): number {
+  if (options.timezone) {
+    return offsetMinutesForTimezone(timestampMs, options.timezone);
+  }
+  if (options.isViewer && options.viewerTimezoneOffsetMinutes !== undefined) {
+    return options.viewerTimezoneOffsetMinutes;
+  }
+  return 0;
+}
+
+export type LeaderboardMetric = 'prsThisMonth' | 'workoutsThisWeek' | 'currentStreak';
+
+const PRIMARY_LIFT_PATTERNS = ['squat', 'bench press', 'deadlift', 'overhead press'];
+
+export function isPrimaryLift(exerciseName: string): boolean {
+  const normalized = exerciseName.toLowerCase();
+  return PRIMARY_LIFT_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
+export type PrDetail = {
+  exerciseName: string;
+  weight: number;
+  completedAt: number;
+  isPrimary: boolean;
+};
+
+export type WorkoutDetail = {
+  completedAt: number;
+  title: string;
+};
+
+export function deriveWorkoutTitle(
+  session: SessionDoc,
+  templateNamesById: Map<string, string>
+): string {
+  if (session.templateId) {
+    const templateName = templateNamesById.get(String(session.templateId));
+    if (templateName) {
+      return templateName;
+    }
+  }
+
+  return 'Custom Workout';
+}
+
+export type ActivityExercise = {
+  exerciseName: string;
+  weight: number;
+  reps: number;
+  isPrimary: boolean;
+  weighted: boolean;
+};
+
+export function computeActivityExercises(session: SessionDoc): ActivityExercise[] {
+  const ordered = [...session.exercises].sort((a, b) => a.order - b.order);
+  const result: ActivityExercise[] = [];
+
+  for (const exercise of ordered) {
+    let best: { weight: number; reps: number } | null = null;
+
+    for (const set of exercise.sets) {
+      if (!set.done) {
+        continue;
+      }
+
+      const weight = set.completedWeight ?? set.weight ?? 0;
+      const reps = set.completedReps ?? set.reps ?? 0;
+      if (
+        !best ||
+        weight > best.weight ||
+        (weight === best.weight && reps > best.reps)
+      ) {
+        best = { weight, reps };
+      }
+    }
+
+    if (!best) {
+      continue;
+    }
+
+    result.push({
+      exerciseName: exercise.exerciseName,
+      weight: best.weight,
+      reps: best.reps,
+      isPrimary: isPrimaryLift(exercise.exerciseName),
+      weighted: best.weight > 0,
+    });
+  }
+
+  return result;
+}
+
+export function countDoneSets(session: SessionDoc): number {
+  return session.exercises.reduce(
+    (total, exercise) => total + exercise.sets.filter((set) => set.done).length,
+    0
+  );
+}
+
+export type StreakDetail = {
+  lastWorkoutAt: number | null;
+  workedToday: boolean;
+};
+
+export type LeaderboardDetail =
+  | { type: 'prsThisMonth'; prs: PrDetail[] }
+  | { type: 'workoutsThisWeek'; workouts: WorkoutDetail[] }
+  | { type: 'currentStreak'; lastWorkoutAt: number | null; workedToday: boolean };
+
+export function getCompletedSessions(sessions: SessionDoc[]): SessionDoc[] {
+  return sessions.filter((session) => session.status === 'completed' && session.completedAt !== undefined);
+}
+
+export function getWeekRange(nowMs: number): { startMs: number; endMs: number } {
+  return { startMs: nowMs - MS_PER_WEEK, endMs: nowMs };
+}
+
+export function getMonthRange(nowMs: number): { startMs: number; endMs: number } {
+  return { startMs: nowMs - MS_PER_MONTH, endMs: nowMs };
+}
+
+export function computeWorkoutsInRange(
+  sessions: SessionDoc[],
+  startMs: number
+): number {
+  return getCompletedSessions(sessions).filter((session) => {
+    const completedAt = session.completedAt ?? 0;
+    return completedAt >= startMs;
+  }).length;
+}
+
+export function computeSetsInRange(
+  sessions: SessionDoc[],
+  startMs: number
+): number {
+  return getCompletedSessions(sessions)
+    .filter((session) => {
+      const completedAt = session.completedAt ?? 0;
+      return completedAt >= startMs;
+    })
+    .reduce((total, session) => {
+      return (
+        total +
+        session.exercises.reduce((exerciseTotal, exercise) => {
+          return exerciseTotal + exercise.sets.filter((set) => set.done).length;
+        }, 0)
+      );
+    }, 0);
+}
+
+export function computeMinutesInRange(
+  sessions: SessionDoc[],
+  startMs: number
+): number {
+  return getCompletedSessions(sessions)
+    .filter((session) => {
+      const completedAt = session.completedAt ?? 0;
+      return completedAt >= startMs;
+    })
+    .reduce((total, session) => {
+      if (!session.completedAt) {
+        return total;
+      }
+      const minutes = Math.round((session.completedAt - session.startedAt) / (1000 * 60));
+      return total + Math.max(minutes, 0);
+    }, 0);
+}
+
+export function computeCurrentStreak(
+  sessions: SessionDoc[],
+  nowMs: number,
+  timezoneOffsetMinutes = 0
+): number {
+  const completed = getCompletedSessions(sessions).sort(
+    (a, b) => (b.completedAt ?? 0) - (a.completedAt ?? 0)
+  );
+
+  if (completed.length === 0) {
+    return 0;
+  }
+
+  const anchorMs = completed[0].completedAt ?? 0;
+  const anchorDayKey = localDateKey(anchorMs, timezoneOffsetMinutes);
+  const todayKey = localDateKey(nowMs, timezoneOffsetMinutes);
+  const yesterdayKey = localDateKeyWithOffset(nowMs, timezoneOffsetMinutes, -1);
+
+  if (anchorDayKey !== todayKey && anchorDayKey !== yesterdayKey) {
+    return 0;
+  }
+
+  const workoutDayKeys = new Set(
+    completed.map((session) => localDateKey(session.completedAt ?? 0, timezoneOffsetMinutes))
+  );
+
+  let streak = 0;
+  for (let dayOffset = 0; ; dayOffset += 1) {
+    const dayKey = localDateKeyWithOffset(anchorMs, timezoneOffsetMinutes, -dayOffset);
+    if (!workoutDayKeys.has(dayKey)) {
+      break;
+    }
+    streak += 1;
+  }
+
+  return streak;
+}
+
+export function computeWorkoutsPerDay(
+  sessions: SessionDoc[],
+  nowMs: number,
+  timezoneOffsetMinutes = 0
+): number[] {
+  const completed = getCompletedSessions(sessions);
+  const dayKeys = Array.from({ length: 7 }, (_, index) =>
+    localDateKeyWithOffset(nowMs, timezoneOffsetMinutes, -(6 - index))
+  );
+
+  return dayKeys.map(
+    (dayKey) =>
+      completed.filter(
+        (session) => localDateKey(session.completedAt ?? 0, timezoneOffsetMinutes) === dayKey
+      ).length
+  );
+}
+
+export function computePrDetailsInRange(
+  sessions: SessionDoc[],
+  startMs: number
+): PrDetail[] {
+  const completed = getCompletedSessions(sessions).sort(
+    (a, b) => (a.completedAt ?? 0) - (b.completedAt ?? 0)
+  );
+
+  const maxByExercise = new Map<string, number>();
+  const prs: PrDetail[] = [];
+
+  for (const session of completed) {
+    const completedAt = session.completedAt ?? 0;
+
+    for (const exercise of session.exercises) {
+      for (const set of exercise.sets) {
+        if (!set.done) {
+          continue;
+        }
+
+        const weight = set.completedWeight ?? set.weight;
+        if (weight === undefined || weight <= 0) {
+          continue;
+        }
+
+        const exerciseKey = String(exercise.exerciseId);
+        const previousMax = maxByExercise.get(exerciseKey) ?? -Infinity;
+
+        if (weight > previousMax && completedAt >= startMs) {
+          prs.push({
+            exerciseName: exercise.exerciseName,
+            weight,
+            completedAt,
+            isPrimary: isPrimaryLift(exercise.exerciseName),
+          });
+        }
+
+        if (weight > previousMax) {
+          maxByExercise.set(exerciseKey, weight);
+        }
+      }
+    }
+  }
+
+  return prs.sort((a, b) => {
+    if (a.isPrimary !== b.isPrimary) {
+      return a.isPrimary ? -1 : 1;
+    }
+    return b.completedAt - a.completedAt;
+  });
+}
+
+export function computeWorkoutDetailsInRange(
+  sessions: SessionDoc[],
+  startMs: number,
+  templateNamesById: Map<string, string> = new Map()
+): WorkoutDetail[] {
+  return getCompletedSessions(sessions)
+    .filter((session) => {
+      const completedAt = session.completedAt ?? 0;
+      return completedAt >= startMs;
+    })
+    .sort((a, b) => (b.completedAt ?? 0) - (a.completedAt ?? 0))
+    .map((session) => ({
+      completedAt: session.completedAt ?? 0,
+      title: deriveWorkoutTitle(session, templateNamesById),
+    }));
+}
+
+export function computeStreakDetail(
+  sessions: SessionDoc[],
+  nowMs: number,
+  timezoneOffsetMinutes = 0
+): StreakDetail {
+  const completed = getCompletedSessions(sessions).sort(
+    (a, b) => (b.completedAt ?? 0) - (a.completedAt ?? 0)
+  );
+
+  if (completed.length === 0) {
+    return { lastWorkoutAt: null, workedToday: false };
+  }
+
+  const lastWorkoutAt = completed[0].completedAt ?? 0;
+  const todayKey = localDateKey(nowMs, timezoneOffsetMinutes);
+  const lastWorkoutKey = localDateKey(lastWorkoutAt, timezoneOffsetMinutes);
+
+  return {
+    lastWorkoutAt,
+    workedToday: lastWorkoutKey === todayKey,
+  };
+}
+
+export function computeMetricDetail(
+  sessions: SessionDoc[],
+  metric: LeaderboardMetric,
+  nowMs: number,
+  templateNamesById: Map<string, string> = new Map(),
+  timezoneOffsetMinutes = 0
+): LeaderboardDetail {
+  const weekRange = getWeekRange(nowMs);
+  const monthRange = getMonthRange(nowMs);
+
+  switch (metric) {
+    case 'prsThisMonth':
+      return {
+        type: 'prsThisMonth',
+        prs: computePrDetailsInRange(sessions, monthRange.startMs),
+      };
+    case 'workoutsThisWeek':
+      return {
+        type: 'workoutsThisWeek',
+        workouts: computeWorkoutDetailsInRange(
+          sessions,
+          weekRange.startMs,
+          templateNamesById
+        ),
+      };
+    case 'currentStreak': {
+      const streakDetail = computeStreakDetail(sessions, nowMs, timezoneOffsetMinutes);
+      return {
+        type: 'currentStreak',
+        lastWorkoutAt: streakDetail.lastWorkoutAt,
+        workedToday: streakDetail.workedToday,
+      };
+    }
+  }
+}
+
+export function computePrCountInRange(
+  sessions: SessionDoc[],
+  startMs: number
+): number {
+  const completed = getCompletedSessions(sessions).sort(
+    (a, b) => (a.completedAt ?? 0) - (b.completedAt ?? 0)
+  );
+
+  const maxByExercise = new Map<string, number>();
+  let prCount = 0;
+
+  for (const session of completed) {
+    const completedAt = session.completedAt ?? 0;
+
+    for (const exercise of session.exercises) {
+      for (const set of exercise.sets) {
+        if (!set.done) {
+          continue;
+        }
+
+        const weight = set.completedWeight ?? set.weight;
+        if (weight === undefined || weight <= 0) {
+          continue;
+        }
+
+        const exerciseKey = String(exercise.exerciseId);
+        const previousMax = maxByExercise.get(exerciseKey) ?? -Infinity;
+
+        if (weight > previousMax && completedAt >= startMs) {
+          prCount += 1;
+        }
+
+        if (weight > previousMax) {
+          maxByExercise.set(exerciseKey, weight);
+        }
+      }
+    }
+  }
+
+  return prCount;
+}
+
+export function computeMetricValue(
+  sessions: SessionDoc[],
+  metric: LeaderboardMetric,
+  nowMs: number,
+  timezoneOffsetMinutes = 0
+): number {
+  const weekRange = getWeekRange(nowMs);
+  const monthRange = getMonthRange(nowMs);
+
+  switch (metric) {
+    case 'workoutsThisWeek':
+      return computeWorkoutsInRange(sessions, weekRange.startMs);
+    case 'currentStreak':
+      return computeCurrentStreak(sessions, nowMs, timezoneOffsetMinutes);
+    case 'prsThisMonth':
+      return computePrCountInRange(sessions, monthRange.startMs);
+  }
+}

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -1,0 +1,366 @@
+import { v } from 'convex/values';
+import { internal } from './_generated/api';
+import type { Id } from './_generated/dataModel';
+import { internalMutation, mutation, query, type MutationCtx, type QueryCtx } from './_generated/server';
+import { ensureCurrentUser, getCurrentUser } from './lib/auth';
+import { computeMetricValue } from './lib/stats';
+
+const WORKOUT_NOTIFY_DEBOUNCE_MS = 30 * 60 * 1000;
+const WEEKLY_RECAP_HOUR = 19;
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+const settingsValidator = v.object({
+  notifyOnGroupWorkout: v.boolean(),
+  notifyWeeklyRecap: v.boolean(),
+  timezone: v.optional(v.string()),
+  hasPushToken: v.boolean(),
+});
+
+async function getSettingsForUser(ctx: QueryCtx, userId: Id<'users'>) {
+  return await ctx.db
+    .query('userNotificationSettings')
+    .withIndex('by_user', (q) => q.eq('userId', userId))
+    .first();
+}
+
+async function getOrCreateSettings(ctx: MutationCtx, userId: Id<'users'>) {
+  const existing = await ctx.db
+    .query('userNotificationSettings')
+    .withIndex('by_user', (q) => q.eq('userId', userId))
+    .first();
+
+  if (existing) {
+    return existing;
+  }
+
+  const settingsId = await ctx.db.insert('userNotificationSettings', {
+    userId,
+    notifyOnGroupWorkout: true,
+    notifyWeeklyRecap: true,
+    timezone: undefined,
+    expoPushToken: undefined,
+    lastWeeklyRecapSentAt: undefined,
+  });
+
+  return await ctx.db.get(settingsId);
+}
+
+export const getSettings = query({
+  args: {},
+  returns: settingsValidator,
+  handler: async (ctx) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return {
+        notifyOnGroupWorkout: true,
+        notifyWeeklyRecap: true,
+        timezone: undefined,
+        hasPushToken: false,
+      };
+    }
+
+    const settings = await getSettingsForUser(ctx, user._id);
+
+    return {
+      notifyOnGroupWorkout: settings?.notifyOnGroupWorkout ?? true,
+      notifyWeeklyRecap: settings?.notifyWeeklyRecap ?? true,
+      timezone: settings?.timezone,
+      hasPushToken: Boolean(settings?.expoPushToken),
+    };
+  },
+});
+
+export const registerPushToken = mutation({
+  args: {
+    expoPushToken: v.string(),
+    timezone: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, { expoPushToken, timezone }) => {
+    const user = await ensureCurrentUser(ctx);
+    const settings = await getOrCreateSettings(ctx, user._id);
+
+    if (settings) {
+      await ctx.db.patch(settings._id, {
+        expoPushToken,
+        timezone: timezone ?? settings.timezone,
+      });
+    }
+
+    return null;
+  },
+});
+
+export const updateNotificationPrefs = mutation({
+  args: {
+    notifyOnGroupWorkout: v.optional(v.boolean()),
+    notifyWeeklyRecap: v.optional(v.boolean()),
+    timezone: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const user = await ensureCurrentUser(ctx);
+    const settings = await getOrCreateSettings(ctx, user._id);
+
+    if (!settings) {
+      throw new Error('Notification settings not found');
+    }
+
+    const updates: Record<string, boolean | string | undefined> = {};
+    if (args.notifyOnGroupWorkout !== undefined) {
+      updates.notifyOnGroupWorkout = args.notifyOnGroupWorkout;
+    }
+    if (args.notifyWeeklyRecap !== undefined) {
+      updates.notifyWeeklyRecap = args.notifyWeeklyRecap;
+    }
+    if (args.timezone !== undefined) {
+      updates.timezone = args.timezone;
+    }
+
+    await ctx.db.patch(settings._id, updates);
+    return null;
+  },
+});
+
+export const notifyGroupInvite = internalMutation({
+  args: { invitationId: v.id('groupInvitations') },
+  returns: v.null(),
+  handler: async (ctx, { invitationId }) => {
+    const invite = await ctx.db.get(invitationId);
+    if (!invite || invite.status !== 'pending') {
+      return null;
+    }
+
+    const group = await ctx.db.get(invite.groupId);
+    const inviter = await ctx.db.get(invite.invitedByUserId);
+    if (!group) {
+      return null;
+    }
+
+    const settings = await ctx.db
+      .query('userNotificationSettings')
+      .withIndex('by_user', (q) => q.eq('userId', invite.invitedUserId))
+      .first();
+
+    if (!settings?.expoPushToken) {
+      return null;
+    }
+
+    const inviterName = inviter?.displayName ?? 'Someone';
+
+    await ctx.scheduler.runAfter(0, internal.notificationsActions.sendPush, {
+      tokens: [settings.expoPushToken],
+      title: 'Group invitation',
+      body: `${inviterName} invited you to join ${group.name}`,
+      data: { type: 'group_invite', invitationId },
+    });
+
+    return null;
+  },
+});
+
+export const notifyGroupWorkout = internalMutation({
+  args: {
+    userId: v.id('users'),
+    sessionId: v.id('sessions'),
+  },
+  returns: v.null(),
+  handler: async (ctx, { userId, sessionId }) => {
+    const session = await ctx.db.get(sessionId);
+    if (!session || session.status !== 'completed' || !session.completedAt) {
+      return null;
+    }
+
+    const recentSessions = await ctx.db
+      .query('sessions')
+      .withIndex('by_user_started', (q) => q.eq('userId', userId))
+      .order('desc')
+      .take(5);
+
+    const recentCompleted = recentSessions.filter(
+      (item) =>
+        item.status === 'completed' &&
+        item._id !== sessionId &&
+        item.completedAt !== undefined &&
+        session.completedAt !== undefined &&
+        session.completedAt - item.completedAt < WORKOUT_NOTIFY_DEBOUNCE_MS
+    );
+
+    if (recentCompleted.length > 0) {
+      return null;
+    }
+
+    const actor = await ctx.db.get(userId);
+    const actorName = actor?.displayName ?? 'Someone';
+    const template = session.templateId ? await ctx.db.get(session.templateId) : null;
+    const workoutLabel = template?.name ?? `${session.exercises.length} exercises`;
+
+    const memberships = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .collect();
+
+    const groupIds = new Set(memberships.map((membership) => membership.groupId));
+    const recipientTokens: string[] = [];
+
+    for (const groupId of groupIds) {
+      const members = await ctx.db
+        .query('groupMembers')
+        .withIndex('by_group', (q) => q.eq('groupId', groupId))
+        .collect();
+
+      for (const member of members) {
+        if (member.userId === userId) {
+          continue;
+        }
+
+        const settings = await ctx.db
+          .query('userNotificationSettings')
+          .withIndex('by_user', (q) => q.eq('userId', member.userId))
+          .first();
+
+        if (!settings?.expoPushToken || !settings.notifyOnGroupWorkout) {
+          continue;
+        }
+
+        recipientTokens.push(settings.expoPushToken);
+      }
+    }
+
+    const uniqueTokens = [...new Set(recipientTokens)];
+    if (uniqueTokens.length === 0) {
+      return null;
+    }
+
+    await ctx.scheduler.runAfter(0, internal.notificationsActions.sendPush, {
+      tokens: uniqueTokens,
+      title: `${actorName} finished a workout`,
+      body: workoutLabel,
+      data: { type: 'group_workout', sessionId },
+    });
+
+    return null;
+  },
+});
+
+export const sendWeeklyRecaps = internalMutation({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    const now = Date.now();
+    const allSettings = await ctx.db.query('userNotificationSettings').collect();
+
+    for (const settings of allSettings) {
+      if (!settings.notifyWeeklyRecap || !settings.expoPushToken) {
+        continue;
+      }
+
+      const timezone = settings.timezone ?? 'UTC';
+      const localParts = getLocalDateParts(now, timezone);
+      if (localParts.weekday !== 0 || localParts.hour !== WEEKLY_RECAP_HOUR) {
+        continue;
+      }
+
+      if (
+        settings.lastWeeklyRecapSentAt !== undefined &&
+        now - settings.lastWeeklyRecapSentAt < MS_PER_WEEK - 60 * 60 * 1000
+      ) {
+        continue;
+      }
+
+      const memberships = await ctx.db
+        .query('groupMembers')
+        .withIndex('by_user', (q) => q.eq('userId', settings.userId))
+        .collect();
+
+      if (memberships.length === 0) {
+        continue;
+      }
+
+      const recapMessages: string[] = [];
+
+      for (const membership of memberships) {
+        const group = await ctx.db.get(membership.groupId);
+        if (!group) {
+          continue;
+        }
+
+        const members = await ctx.db
+          .query('groupMembers')
+          .withIndex('by_group', (q) => q.eq('groupId', group._id))
+          .collect();
+
+        const entries = await Promise.all(
+          members.map(async (member) => {
+            const memberUser = await ctx.db.get(member.userId);
+            const sessions = await ctx.db
+              .query('sessions')
+              .withIndex('by_user_started', (q) => q.eq('userId', member.userId))
+              .collect();
+
+            return {
+              displayName: memberUser?.displayName ?? 'Athlete',
+              value: computeMetricValue(sessions, 'workoutsThisWeek', now),
+            };
+          })
+        );
+
+        entries.sort((a, b) => b.value - a.value);
+        const leader = entries[0];
+        if (!leader || leader.value <= 0) {
+          recapMessages.push(`${group.name}: no workouts logged this week`);
+        } else {
+          recapMessages.push(
+            `${group.name}: ${leader.displayName} leads with ${leader.value} workout${leader.value === 1 ? '' : 's'}`
+          );
+        }
+      }
+
+      if (recapMessages.length === 0) {
+        continue;
+      }
+
+      await ctx.scheduler.runAfter(0, internal.notificationsActions.sendPush, {
+        tokens: [settings.expoPushToken],
+        title: 'Weekly group recap',
+        body: recapMessages.join(' • '),
+        data: { type: 'weekly_recap' },
+      });
+
+      await ctx.db.patch(settings._id, { lastWeeklyRecapSentAt: now });
+    }
+
+    return null;
+  },
+});
+
+function getLocalDateParts(timestamp: number, timezone: string): { weekday: number; hour: number } {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      weekday: 'short',
+      hour: 'numeric',
+      hour12: false,
+    });
+    const parts = formatter.formatToParts(new Date(timestamp));
+    const weekdayLabel = parts.find((part) => part.type === 'weekday')?.value ?? 'Sun';
+    const hourValue = Number(parts.find((part) => part.type === 'hour')?.value ?? '0');
+    const weekdayMap: Record<string, number> = {
+      Sun: 0,
+      Mon: 1,
+      Tue: 2,
+      Wed: 3,
+      Thu: 4,
+      Fri: 5,
+      Sat: 6,
+    };
+
+    return {
+      weekday: weekdayMap[weekdayLabel] ?? 0,
+      hour: Number.isNaN(hourValue) ? 0 : hourValue,
+    };
+  } catch {
+    const date = new Date(timestamp);
+    return { weekday: date.getUTCDay(), hour: date.getUTCHours() };
+  }
+}

--- a/convex/notificationsActions.ts
+++ b/convex/notificationsActions.ts
@@ -1,0 +1,42 @@
+"use node";
+
+import { v } from 'convex/values';
+import { internalAction } from './_generated/server';
+
+export const sendPush = internalAction({
+  args: {
+    tokens: v.array(v.string()),
+    title: v.string(),
+    body: v.string(),
+    data: v.optional(v.record(v.string(), v.string())),
+  },
+  returns: v.null(),
+  handler: async (_ctx, { tokens, title, body, data }) => {
+    const messages = tokens.map((token) => ({
+      to: token,
+      sound: 'default',
+      title,
+      body,
+      data,
+    }));
+
+    for (let i = 0; i < messages.length; i += 100) {
+      const chunk = messages.slice(i, i + 100);
+      const response = await fetch('https://exp.host/--/api/v2/push/send', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Accept-encoding': 'gzip, deflate',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(chunk),
+      });
+
+      if (!response.ok) {
+        console.error('Failed to send push notification', await response.text());
+      }
+    }
+
+    return null;
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -5,6 +5,7 @@ export default defineSchema({
   users: defineTable({
     clerkUserId: v.string(),
     displayName: v.optional(v.string()),
+    imageUrl: v.optional(v.string()),
     createdAt: v.number(),
   }).index('by_clerk_id', ['clerkUserId']),
 
@@ -163,6 +164,44 @@ export default defineSchema({
     .index('by_anon_created', ['anonKey', 'createdAt'])
     .index('by_user_exercise_created', ['userId', 'exerciseId', 'createdAt'])
     .index('by_anon_exercise_created', ['anonKey', 'exerciseId', 'createdAt']),
+
+  groups: defineTable({
+    name: v.string(),
+    inviteCode: v.optional(v.string()),
+    createdByUserId: v.id('users'),
+    createdAt: v.number(),
+  }).index('by_invite_code', ['inviteCode']),
+
+  groupInvitations: defineTable({
+    groupId: v.id('groups'),
+    invitedUserId: v.id('users'),
+    invitedByUserId: v.id('users'),
+    status: v.union(v.literal('pending'), v.literal('accepted'), v.literal('declined')),
+    createdAt: v.number(),
+    respondedAt: v.optional(v.number()),
+  })
+    .index('by_invited_user_status', ['invitedUserId', 'status'])
+    .index('by_group_and_invited_user', ['groupId', 'invitedUserId'])
+    .index('by_group_status', ['groupId', 'status']),
+
+  groupMembers: defineTable({
+    groupId: v.id('groups'),
+    userId: v.id('users'),
+    role: v.union(v.literal('owner'), v.literal('member')),
+    joinedAt: v.number(),
+  })
+    .index('by_group', ['groupId'])
+    .index('by_user', ['userId'])
+    .index('by_group_and_user', ['groupId', 'userId']),
+
+  userNotificationSettings: defineTable({
+    userId: v.id('users'),
+    expoPushToken: v.optional(v.string()),
+    notifyOnGroupWorkout: v.boolean(),
+    notifyWeeklyRecap: v.boolean(),
+    timezone: v.optional(v.string()),
+    lastWeeklyRecapSentAt: v.optional(v.number()),
+  }).index('by_user', ['userId']),
 });
 
 

--- a/convex/seedData.ts
+++ b/convex/seedData.ts
@@ -1,4 +1,388 @@
-import { mutation } from './_generated/server';
+import { v } from 'convex/values';
+import type { Id } from './_generated/dataModel';
+import { mutation, type MutationCtx } from './_generated/server';
+
+const DEMO_GROUP_NAME = 'Weekend Warriors';
+const DEMO_CLERK_PREFIX = 'seed_demo_';
+
+type ExerciseSeed = {
+  exerciseId: Id<'exercises'>;
+  exerciseName: string;
+  sets: Array<{ reps: number; weight: number }>;
+};
+
+function completedAtForDaysAgo(daysAgo: number, now: number): number {
+  const date = new Date(now);
+  date.setHours(18, 0, 0, 0);
+  date.setDate(date.getDate() - daysAgo);
+  return date.getTime();
+}
+
+async function insertCompletedWorkout(
+  ctx: MutationCtx,
+  userId: Id<'users'>,
+  completedAt: number,
+  durationMin: number,
+  exercises: ExerciseSeed[],
+  templateId?: Id<'templates'>
+) {
+  const startedAt = completedAt - durationMin * 60 * 1000;
+  await ctx.db.insert('sessions', {
+    userId,
+    templateId,
+    status: 'completed',
+    startedAt,
+    completedAt,
+    exercises: exercises.map((exercise, index) => ({
+      exerciseId: exercise.exerciseId,
+      exerciseName: exercise.exerciseName,
+      order: index + 1,
+      sets: exercise.sets.map((set) => ({
+        reps: set.reps,
+        weight: set.weight,
+        done: true,
+        completedReps: set.reps,
+        completedWeight: set.weight,
+        completedAt,
+      })),
+    })),
+    createdAt: startedAt,
+  });
+}
+
+async function getOrCreateSeedUser(
+  ctx: MutationCtx,
+  clerkUserId: string,
+  displayName: string,
+  now: number
+): Promise<Id<'users'>> {
+  const existing = await ctx.db
+    .query('users')
+    .withIndex('by_clerk_id', (q: any) => q.eq('clerkUserId', clerkUserId))
+    .first();
+  if (existing) {
+    return existing._id;
+  }
+  return await ctx.db.insert('users', {
+    clerkUserId,
+    displayName,
+    createdAt: now,
+  });
+}
+
+export const seedDemoGroup = mutation({
+  args: {
+    ownerMatch: v.string(),
+    recreate: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    message: v.string(),
+    groupId: v.id('groups'),
+    ownerDisplayName: v.string(),
+    members: v.array(v.string()),
+  }),
+  handler: async (ctx, { ownerMatch, recreate }) => {
+    const now = Date.now();
+    const needle = ownerMatch.trim().toLowerCase();
+
+    const allUsers = await ctx.db.query('users').collect();
+    const owner = allUsers.find((user) => {
+      const displayName = (user.displayName ?? '').toLowerCase();
+      const clerkId = user.clerkUserId.toLowerCase();
+      return displayName.includes(needle) || clerkId.includes(needle);
+    });
+
+    if (!owner) {
+      const available = allUsers
+        .map((user) => user.displayName ?? user.clerkUserId)
+        .join(', ');
+      throw new Error(`No user matching "${ownerMatch}". Available: ${available || 'none'}`);
+    }
+
+    const ownerMemberships = await ctx.db
+      .query('groupMembers')
+      .withIndex('by_user', (q) => q.eq('userId', owner._id))
+      .collect();
+
+    for (const membership of ownerMemberships) {
+      const group = await ctx.db.get(membership.groupId);
+      if (group?.name !== DEMO_GROUP_NAME) {
+        continue;
+      }
+
+      if (!recreate) {
+        return {
+          message: 'Demo group already exists',
+          groupId: group._id,
+          ownerDisplayName: owner.displayName ?? 'Athlete',
+          members: ['You', 'Mike', 'Sarah', 'Jake'],
+        };
+      }
+
+      const members = await ctx.db
+        .query('groupMembers')
+        .withIndex('by_group', (q) => q.eq('groupId', group._id))
+        .collect();
+      for (const member of members) {
+        await ctx.db.delete(member._id);
+      }
+
+      const invites = await ctx.db
+        .query('groupInvitations')
+        .withIndex('by_group_status', (q) => q.eq('groupId', group._id).eq('status', 'pending'))
+        .collect();
+      for (const invite of invites) {
+        await ctx.db.delete(invite._id);
+      }
+
+      await ctx.db.delete(group._id);
+    }
+
+    const exercises = await ctx.db.query('exercises').collect();
+    if (exercises.length < 3) {
+      throw new Error('Need at least 3 exercises in the database. Run seedData:initializeApp first.');
+    }
+
+    const benchPress = exercises.find((exercise) => exercise.name === 'Bench Press') ?? exercises[0];
+    const backSquat = exercises.find((exercise) => exercise.name === 'Back Squat') ?? exercises[1];
+    const pullUps = exercises.find((exercise) => exercise.name === 'Pull-ups') ?? exercises[2];
+    const romanianDeadlift =
+      exercises.find((exercise) => exercise.name === 'Romanian Deadlift') ?? exercises[1];
+    const overheadPress =
+      exercises.find((exercise) => exercise.name === 'Overhead Press') ?? exercises[0];
+    const bentOverRows =
+      exercises.find((exercise) => exercise.name === 'Bent-over Rows') ?? exercises[2];
+
+    const allTemplates = await ctx.db.query('templates').collect();
+    const legsTemplate =
+      allTemplates.find((template) => template.name === 'Legs 1 - Squat Focus') ?? allTemplates[0];
+    const chestTemplate =
+      allTemplates.find((template) => template.name === 'Chest 1 - Bench Focus') ?? allTemplates[1];
+    const frontSquatTemplate =
+      allTemplates.find((template) => template.name === 'Legs 2 - Front Squat Focus') ?? legsTemplate;
+
+    if (!legsTemplate || !chestTemplate) {
+      throw new Error('Workout templates not found. Run seedData:initializeApp first.');
+    }
+
+    const mikeId = await getOrCreateSeedUser(ctx, `${DEMO_CLERK_PREFIX}mike`, 'Mike', now);
+    const sarahId = await getOrCreateSeedUser(ctx, `${DEMO_CLERK_PREFIX}sarah`, 'Sarah', now);
+    const jakeId = await getOrCreateSeedUser(ctx, `${DEMO_CLERK_PREFIX}jake`, 'Jake', now);
+
+    const demoUserIds = [mikeId, sarahId, jakeId];
+    for (const userId of demoUserIds) {
+      const sessions = await ctx.db
+        .query('sessions')
+        .withIndex('by_user_started', (q) => q.eq('userId', userId))
+        .collect();
+      for (const session of sessions) {
+        await ctx.db.delete(session._id);
+      }
+    }
+
+    const groupId = await ctx.db.insert('groups', {
+      name: DEMO_GROUP_NAME,
+      createdByUserId: owner._id,
+      createdAt: now,
+    });
+
+    await ctx.db.insert('groupMembers', {
+      groupId,
+      userId: owner._id,
+      role: 'owner',
+      joinedAt: now,
+    });
+
+    for (const memberId of demoUserIds) {
+      await ctx.db.insert('groupMembers', {
+        groupId,
+        userId: memberId,
+        role: 'member',
+        joinedAt: now,
+      });
+    }
+
+    const bench = (weight: number, count = 4) =>
+      Array.from({ length: count }, () => ({ reps: 5, weight }));
+    const squat = (weight: number, count = 3) =>
+      Array.from({ length: count }, () => ({ reps: 8, weight }));
+    const pull = (count = 3) =>
+      Array.from({ length: count }, () => ({ reps: 8, weight: 0 }));
+
+    const mikeWorkouts: Array<{
+      daysAgo: number;
+      durationMin: number;
+      benchWeight: number;
+      squatWeight: number;
+      rdlWeight?: number;
+      ohpWeight?: number;
+      templateId: Id<'templates'>;
+    }> = [
+      { daysAgo: 22, durationMin: 52, benchWeight: 205, squatWeight: 245, rdlWeight: 225, templateId: legsTemplate._id },
+      { daysAgo: 14, durationMin: 55, benchWeight: 225, squatWeight: 275, rdlWeight: 245, templateId: legsTemplate._id },
+      { daysAgo: 7, durationMin: 58, benchWeight: 235, squatWeight: 295, rdlWeight: 255, templateId: frontSquatTemplate._id },
+      { daysAgo: 3, durationMin: 60, benchWeight: 245, squatWeight: 315, rdlWeight: 275, ohpWeight: 115, templateId: legsTemplate._id },
+      { daysAgo: 0, durationMin: 58, benchWeight: 255, squatWeight: 315, rdlWeight: 275, ohpWeight: 120, templateId: legsTemplate._id },
+    ];
+
+    for (const workout of mikeWorkouts) {
+      const exercisesForWorkout: ExerciseSeed[] = [
+        { exerciseId: benchPress._id, exerciseName: benchPress.name, sets: bench(workout.benchWeight, 4) },
+        { exerciseId: backSquat._id, exerciseName: backSquat.name, sets: squat(workout.squatWeight, 4) },
+        { exerciseId: pullUps._id, exerciseName: pullUps.name, sets: pull(3) },
+      ];
+
+      if (workout.rdlWeight !== undefined) {
+        exercisesForWorkout.push({
+          exerciseId: romanianDeadlift._id,
+          exerciseName: romanianDeadlift.name,
+          sets: squat(workout.rdlWeight, 3),
+        });
+      }
+
+      if (workout.ohpWeight !== undefined) {
+        exercisesForWorkout.push({
+          exerciseId: overheadPress._id,
+          exerciseName: overheadPress.name,
+          sets: bench(workout.ohpWeight, 3),
+        });
+      }
+
+      await insertCompletedWorkout(
+        ctx,
+        mikeId,
+        completedAtForDaysAgo(workout.daysAgo, now),
+        workout.durationMin,
+        exercisesForWorkout,
+        workout.templateId
+      );
+    }
+
+    const sarahWorkouts: Array<{
+      daysAgo: number;
+      durationMin: number;
+      benchWeight: number;
+      squatWeight: number;
+      rdlWeight?: number;
+      templateId: Id<'templates'>;
+    }> = [
+      { daysAgo: 20, durationMin: 42, benchWeight: 135, squatWeight: 185, templateId: chestTemplate._id },
+      { daysAgo: 12, durationMin: 44, benchWeight: 145, squatWeight: 205, templateId: legsTemplate._id },
+      { daysAgo: 6, durationMin: 46, benchWeight: 155, squatWeight: 215, rdlWeight: 135, templateId: chestTemplate._id },
+      { daysAgo: 4, durationMin: 45, benchWeight: 165, squatWeight: 225, rdlWeight: 155, templateId: legsTemplate._id },
+      { daysAgo: 3, durationMin: 44, benchWeight: 155, squatWeight: 205, templateId: legsTemplate._id },
+      { daysAgo: 2, durationMin: 48, benchWeight: 155, squatWeight: 205, templateId: legsTemplate._id },
+      { daysAgo: 1, durationMin: 42, benchWeight: 155, squatWeight: 205, templateId: legsTemplate._id },
+      { daysAgo: 0, durationMin: 45, benchWeight: 165, squatWeight: 225, rdlWeight: 165, templateId: legsTemplate._id },
+    ];
+
+    for (const workout of sarahWorkouts) {
+      const exercisesForWorkout: ExerciseSeed[] = [
+        { exerciseId: benchPress._id, exerciseName: benchPress.name, sets: bench(workout.benchWeight, 4) },
+        { exerciseId: backSquat._id, exerciseName: backSquat.name, sets: squat(workout.squatWeight, 3) },
+      ];
+
+      if (workout.rdlWeight !== undefined) {
+        exercisesForWorkout.push({
+          exerciseId: romanianDeadlift._id,
+          exerciseName: romanianDeadlift.name,
+          sets: squat(workout.rdlWeight, 3),
+        });
+      }
+
+      await insertCompletedWorkout(
+        ctx,
+        sarahId,
+        completedAtForDaysAgo(workout.daysAgo, now),
+        workout.durationMin,
+        exercisesForWorkout,
+        workout.templateId
+      );
+    }
+
+    const jakeWorkouts: Array<{
+      daysAgo: number;
+      durationMin: number;
+      squatWeight: number;
+      rowWeight?: number;
+      templateId: Id<'templates'>;
+    }> = [
+      { daysAgo: 12, durationMin: 38, squatWeight: 205, templateId: legsTemplate._id },
+      { daysAgo: 5, durationMin: 35, squatWeight: 225, rowWeight: 155, templateId: legsTemplate._id },
+      { daysAgo: 1, durationMin: 40, squatWeight: 245, rowWeight: 165, templateId: frontSquatTemplate._id },
+    ];
+
+    for (const workout of jakeWorkouts) {
+      const exercisesForWorkout: ExerciseSeed[] = [
+        { exerciseId: backSquat._id, exerciseName: backSquat.name, sets: squat(workout.squatWeight, 3) },
+        { exerciseId: pullUps._id, exerciseName: pullUps.name, sets: pull(4) },
+      ];
+
+      if (workout.rowWeight !== undefined) {
+        exercisesForWorkout.push({
+          exerciseId: bentOverRows._id,
+          exerciseName: bentOverRows.name,
+          sets: bench(workout.rowWeight, 3),
+        });
+      }
+
+      await insertCompletedWorkout(
+        ctx,
+        jakeId,
+        completedAtForDaysAgo(workout.daysAgo, now),
+        workout.durationMin,
+        exercisesForWorkout,
+        workout.templateId
+      );
+    }
+
+    const ownerWorkouts: Array<{
+      daysAgo: number;
+      durationMin: number;
+      benchWeight: number;
+      squatWeight: number;
+      rowWeight?: number;
+      templateId: Id<'templates'>;
+    }> = [
+      { daysAgo: 18, durationMin: 45, benchWeight: 185, squatWeight: 225, templateId: legsTemplate._id },
+      { daysAgo: 10, durationMin: 48, benchWeight: 205, squatWeight: 245, rowWeight: 155, templateId: chestTemplate._id },
+      { daysAgo: 3, durationMin: 52, benchWeight: 215, squatWeight: 255, rowWeight: 165, templateId: legsTemplate._id },
+      { daysAgo: 1, durationMin: 48, benchWeight: 205, squatWeight: 245, templateId: chestTemplate._id },
+      { daysAgo: 0, durationMin: 50, benchWeight: 225, squatWeight: 275, templateId: chestTemplate._id },
+    ];
+
+    for (const workout of ownerWorkouts) {
+      const exercisesForWorkout: ExerciseSeed[] = [
+        { exerciseId: benchPress._id, exerciseName: benchPress.name, sets: bench(workout.benchWeight, 4) },
+        { exerciseId: backSquat._id, exerciseName: backSquat.name, sets: squat(workout.squatWeight, 3) },
+      ];
+
+      if (workout.rowWeight !== undefined) {
+        exercisesForWorkout.push({
+          exerciseId: bentOverRows._id,
+          exerciseName: bentOverRows.name,
+          sets: bench(workout.rowWeight, 3),
+        });
+      }
+
+      await insertCompletedWorkout(
+        ctx,
+        owner._id,
+        completedAtForDaysAgo(workout.daysAgo, now),
+        workout.durationMin,
+        exercisesForWorkout,
+        workout.templateId
+      );
+    }
+
+    return {
+      message: 'Demo group seeded with workout history',
+      groupId,
+      ownerDisplayName: owner.displayName ?? 'Athlete',
+      members: [owner.displayName ?? 'You', 'Mike', 'Sarah', 'Jake'],
+    };
+  },
+});
 
 export const initializeApp = mutation({
   args: {},

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -1,5 +1,7 @@
 import { v } from 'convex/values';
+import { internal } from './_generated/api';
 import { mutation, query } from './_generated/server';
+import { getCurrentUser } from './lib/auth';
 import { computeNextPlannedWeight } from '../utils/workoutProgression';
 const RECENT_SESSION_LIMIT = 25;
 const SETUP_RECENT_SESSION_LIMIT = 8;
@@ -314,16 +316,26 @@ export const recordExerciseRIR = mutation({
 
 export const completeSession = mutation({
   args: { sessionId: v.id('sessions') },
+  returns: v.boolean(),
   handler: async (ctx, { sessionId }) => {
     const s = await ctx.db.get(sessionId);
     if (!s) throw new Error('Session not found');
     if (s.status === 'completed') return true;
     const allSetsDone = s.exercises.every((ex: any) => ex.sets.every((set: any) => set.done));
     if (!allSetsDone) throw new Error('Cannot complete workout until all sets are saved');
+    const completedAt = Date.now();
     await ctx.db.patch(sessionId, {
       status: 'completed',
-      completedAt: Date.now(),
+      completedAt,
     });
+
+    if (s.userId) {
+      await ctx.scheduler.runAfter(0, internal.notifications.notifyGroupWorkout, {
+        userId: s.userId,
+        sessionId,
+      });
+    }
+
     return true;
   },
 });
@@ -345,10 +357,16 @@ export const cancelSession = mutation({
 
 export const historyForUser = query({
   args: { userId: v.id('users') },
+  returns: v.array(v.any()),
   handler: async (ctx, { userId }) => {
+    const user = await getCurrentUser(ctx);
+    if (!user || user._id !== userId) {
+      throw new Error('Unauthorized');
+    }
+
     return await ctx.db
       .query('sessions')
-      .withIndex('by_user_started', q => q.eq('userId', userId))
+      .withIndex('by_user_started', (q) => q.eq('userId', userId))
       .collect();
   },
 });

--- a/convex/stats.ts
+++ b/convex/stats.ts
@@ -1,0 +1,103 @@
+import { v } from 'convex/values';
+import { query } from './_generated/server';
+import { getCurrentUser } from './lib/auth';
+import {
+  computeCurrentStreak,
+  computeWorkoutsInRange,
+  computeWorkoutsPerDay,
+  getCompletedSessions,
+  getWeekRange,
+} from './lib/stats';
+
+const sessionValidator = v.object({
+  _id: v.id('sessions'),
+  status: v.union(v.literal('active'), v.literal('completed')),
+  startedAt: v.number(),
+  completedAt: v.optional(v.number()),
+  exercises: v.array(
+    v.object({
+      exerciseId: v.id('exercises'),
+      exerciseName: v.string(),
+      sets: v.array(
+        v.object({
+          reps: v.number(),
+          done: v.boolean(),
+          completedReps: v.optional(v.number()),
+          completedWeight: v.optional(v.number()),
+        })
+      ),
+    })
+  ),
+});
+
+export const myOverview = query({
+  args: {
+    now: v.number(),
+    timezoneOffsetMinutes: v.number(),
+  },
+  returns: v.object({
+    thisWeekWorkouts: v.number(),
+    totalWorkouts: v.number(),
+    currentStreak: v.number(),
+    workoutsPerDay: v.array(v.number()),
+  }),
+  handler: async (ctx, { now, timezoneOffsetMinutes }) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return {
+        thisWeekWorkouts: 0,
+        totalWorkouts: 0,
+        currentStreak: 0,
+        workoutsPerDay: Array.from({ length: 7 }, () => 0),
+      };
+    }
+
+    const sessions = await ctx.db
+      .query('sessions')
+      .withIndex('by_user_started', (q) => q.eq('userId', user._id))
+      .collect();
+
+    const completed = getCompletedSessions(sessions);
+    const weekRange = getWeekRange(now);
+
+    return {
+      thisWeekWorkouts: computeWorkoutsInRange(sessions, weekRange.startMs),
+      totalWorkouts: completed.length,
+      currentStreak: computeCurrentStreak(sessions, now, timezoneOffsetMinutes),
+      workoutsPerDay: computeWorkoutsPerDay(sessions, now, timezoneOffsetMinutes),
+    };
+  },
+});
+
+export const myHistory = query({
+  args: {},
+  returns: v.array(sessionValidator),
+  handler: async (ctx) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      return [];
+    }
+
+    const sessions = await ctx.db
+      .query('sessions')
+      .withIndex('by_user_started', (q) => q.eq('userId', user._id))
+      .collect();
+
+    return sessions.map((session) => ({
+      _id: session._id,
+      status: session.status,
+      startedAt: session.startedAt,
+      completedAt: session.completedAt,
+      exercises: session.exercises.map((exercise) => ({
+        exerciseId: exercise.exerciseId,
+        exerciseName: exercise.exerciseName,
+        sets: exercise.sets.map((set) => ({
+          reps: set.reps,
+          done: set.done,
+          completedReps: set.completedReps,
+          completedWeight: set.completedWeight,
+        })),
+      })),
+    }));
+  },
+});

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -2,17 +2,34 @@ import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 
 export const getOrCreate = mutation({
-  args: { clerkUserId: v.string(), displayName: v.optional(v.string()) },
+  args: {
+    clerkUserId: v.string(),
+    displayName: v.optional(v.string()),
+    imageUrl: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const existing = await ctx.db
       .query('users')
       .withIndex('by_clerk_id', q => q.eq('clerkUserId', args.clerkUserId))
       .first();
-    if (existing) return existing._id;
+    if (existing) {
+      const patch: { displayName?: string; imageUrl?: string } = {};
+      if (args.displayName !== undefined && args.displayName !== existing.displayName) {
+        patch.displayName = args.displayName;
+      }
+      if (args.imageUrl !== undefined && args.imageUrl !== existing.imageUrl) {
+        patch.imageUrl = args.imageUrl;
+      }
+      if (Object.keys(patch).length > 0) {
+        await ctx.db.patch(existing._id, patch);
+      }
+      return existing._id;
+    }
     const now = Date.now();
     return await ctx.db.insert('users', {
       clerkUserId: args.clerkUserId,
       displayName: args.displayName,
+      imageUrl: args.imageUrl,
       createdAt: now,
     });
   },

--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import Constants from 'expo-constants';
+import { useConvexAuth, useMutation } from 'convex/react';
+import { useAuth, useUser } from '@clerk/clerk-expo';
+import { api } from '@/convex/_generated/api';
+
+function getDeviceTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return 'UTC';
+  }
+}
+
+export function usePushNotifications() {
+  const { isSignedIn } = useAuth();
+  const { user } = useUser();
+  const { isAuthenticated, isLoading } = useConvexAuth();
+  const registerPushToken = useMutation(api.notifications.registerPushToken);
+  const registeredUserIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isSignedIn || !user) {
+      registeredUserIdRef.current = null;
+      return;
+    }
+
+    const register = async () => {
+      if (isLoading || !isAuthenticated || registeredUserIdRef.current === user.id) {
+        return;
+      }
+
+      if (Platform.OS === 'web') {
+        return;
+      }
+
+      const { status: existingStatus } = await Notifications.getPermissionsAsync();
+      let finalStatus = existingStatus;
+      if (existingStatus !== 'granted') {
+        const { status } = await Notifications.requestPermissionsAsync();
+        finalStatus = status;
+      }
+
+      if (finalStatus !== 'granted') {
+        return;
+      }
+
+      const projectId =
+        Constants.expoConfig?.extra?.eas?.projectId ??
+        Constants.easConfig?.projectId;
+
+      const tokenResponse = await Notifications.getExpoPushTokenAsync(
+        projectId ? { projectId } : undefined
+      );
+
+      await registerPushToken({
+        expoPushToken: tokenResponse.data,
+        timezone: getDeviceTimezone(),
+      });
+
+      registeredUserIdRef.current = user.id;
+    };
+
+    void register();
+  }, [isSignedIn, user, isLoading, isAuthenticated, registerPushToken]);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo": "~53.0.27",
         "expo-auth-session": "~6.2.1",
         "expo-blur": "~14.1.5",
+        "expo-clipboard": "~8.0.8",
         "expo-constants": "~17.1.8",
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
@@ -10662,6 +10663,17 @@
       "version": "14.1.5",
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-14.1.5.tgz",
       "integrity": "sha512-CCLJHxN4eoAl06ESKT3CbMasJ98WsjF9ZQEJnuxtDb9ffrYbZ+g9ru84fukjNUOTtc8A8yXE5z8NgY1l0OMrmQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-8.0.8.tgz",
+      "integrity": "sha512-VKoBkHIpZZDJTB0jRO4/PZskHdMNOEz3P/41tmM6fDuODMpqhvyWK053X0ebspkxiawJX9lX33JXHBCvVsTTOA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "expo": "~53.0.27",
     "expo-auth-session": "~6.2.1",
     "expo-blur": "~14.1.5",
+    "expo-clipboard": "~8.0.8",
     "expo-constants": "~17.1.8",
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",


### PR DESCRIPTION
## Summary

- Adds a **Groups** tab where signed-in users can create groups, invite members, and view a group leaderboard plus activity feed
- Introduces a shared Convex stats layer (`convex/lib/stats.ts`, `convex/stats.ts`) powering profile overview, leaderboard rankings, and activity highlights
- Adds **push notification** support with user-configurable prefs for group workout completions and weekly recap summaries
- Refactors the profile screen to consume `stats.myOverview` instead of computing streaks and weekly counts on the client

## Backend

- New tables: `groups`, `groupMembers`, `groupInvitations`, `userNotificationSettings`
- Group CRUD, invites, and membership checks via `convex/groups.ts` and `convex/lib/auth.ts`
- Leaderboard metrics: PRs this month, workouts this week, current streak (`convex/leaderboard.ts`)
- Activity feed with per-exercise best-set highlights (`computeActivityExercises`)
- Push token registration and notification dispatch (`convex/notifications.ts`, `notificationsActions.ts`, `crons.ts`)
- Demo seed mutation (`seedDemoGroup`) for local testing with realistic workout history
- Session completion triggers group workout notifications for members

## Frontend

- Groups list and group detail screens with Leaderboard / Activity tabs
- Leaderboard metric picker with expandable member detail
- Notification toggles in Settings
- `AppToast` provider and push registration hook wired into root layout
- Profile stats now come from the backend with client timezone offset passed through

## Bug fixes included

- **Streak recency:** `computeCurrentStreak` returns 0 unless the last workout was today or yesterday
- **Timezone alignment:** local day bucketing for profile charts and per-member leaderboard streaks
- **Rolling windows:** leaderboard counts use open-ended `completedAt >= startMs` so post-mount workouts aren’t excluded
- **Bodyweight sets:** activity feed picks highest reps when weight is equal (e.g. pull-ups 8/8/12 → 12 reps)
- **Zero-weight PRs:** bodyweight sets no longer count as personal records
- **Push re-registration:** token re-registers correctly after sign-out / sign-in

## Test plan

- [ ] Sign in and confirm Groups tab appears; hidden when signed out
- [ ] Create a group, invite a user, accept invite from second account
- [ ] Run `seedDemoGroup` and verify leaderboard ranks update for workouts this week, PRs this month, and current streak
- [ ] Confirm a user with an old multi-day streak but no recent workouts shows streak **0**
- [ ] Complete a workout and verify it appears in the group activity feed with correct best sets (including bodyweight reps)
- [ ] Toggle notification prefs in Settings; complete a workout and confirm group members receive a push (physical device)
- [ ] Profile screen shows matching streak, weekly count, and 7-day chart vs group leaderboard
- [ ] Sign out and back in; confirm push token re-registers